### PR TITLE
fetch branches from origin

### DIFF
--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
@@ -520,6 +520,8 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
                 "Fetching remote branch '" + gitFlowConfig.getOrigin() + " "
                         + branchName + "'.");
 
+        executeGitCommand("checkout", branchName);
+
         CommandResult result = executeGitCommandExitCode("fetch", "--quiet",
                 gitFlowConfig.getOrigin(), branchName);
 


### PR DESCRIPTION
We have cases when we pull only one branch for example master.(situation for example in CI tools)
In this case we can't execute command `git rev-list --left-right --count develop...origin/develop`.
So with this fix we will checkout to branch before we execute this command.
