### PR TITLE
Executables in env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.classpath
 /.project
 /target
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /.project
 /target
 .idea/
+*.iml

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ If version has qualifier then it will not be removed in the release or hotfix go
 # Plugin Common Parameters
 
 All parameters are optional. The `gitFlowConfig` parameters defaults are the same as in the example below.
-Maven and Git executables are assumed to be in the PATH, if executables are not available in the PATH or you want to use different version use `mvnExecutable` and `gitExecutable` parameters.
+Maven and Git executables are assumed to be in the PATH, if executables are not available in the PATH or you want to use different version use `mvnExecutable` and `gitExecutable` parameters (by default the plugin will first source these variables from the shell env).
 The `installProject` parameter controls whether the Maven `install` goal will be called during the mojo execution. The default value for this parameter is `false` (i.e. the project will NOT be installed).
 Since `1.0.7` version of this plugin the output of the executed commands will NOT be printed into the console. This can be changed by setting `verbose` parameter to `true`.
 

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
@@ -54,6 +54,8 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /** Success exit code. */
     private static final int SUCCESS_EXIT_CODE = 0;
+    public static final String GIT_EXECUTABLE = "gitExecutable";
+    public static final String MVN_EXECUTABLE = "mvnExecutable";
 
     /** Command line for Git executable. */
     private final Commandline cmdGit = new Commandline();
@@ -123,13 +125,13 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
     /**
      * The path to the Maven executable. Defaults to "mvn".
      */
-    @Parameter(property = "mvnExecutable")
-    private String mvnExecutable = getenv("mvnExecutable");
+    @Parameter(property = MVN_EXECUTABLE)
+    private String mvnExecutable = getenv(MVN_EXECUTABLE);
     /**
      * The path to the Git executable. Defaults to "git".
      */
-    @Parameter(property = "gitExecutable")
-    private String gitExecutable = getenv("gitExecutable");
+    @Parameter(property = GIT_EXECUTABLE)
+    private String gitExecutable = getenv(GIT_EXECUTABLE);
 
     /** Maven session. */
     @Component

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
@@ -123,12 +123,14 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
     private boolean verbose = false;
 
     /**
-     * The path to the Maven executable. Defaults to "mvn".
+     * The path to the Maven executable - first looks for shell variable of same name, if not found and
+     * property not set then defaults to "mvn".
      */
     @Parameter(property = MVN_EXECUTABLE)
     private String mvnExecutable = getenv(MVN_EXECUTABLE);
     /**
-     * The path to the Git executable. Defaults to "git".
+     * The path to the Git executable - first looks for shell variable of same name, if not found and
+     * property not set then defaults to "git".
      */
     @Parameter(property = GIT_EXECUTABLE)
     private String gitExecutable = getenv(GIT_EXECUTABLE);

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
@@ -35,6 +35,8 @@ import org.codehaus.plexus.util.cli.CommandLineException;
 import org.codehaus.plexus.util.cli.CommandLineUtils;
 import org.codehaus.plexus.util.cli.Commandline;
 
+import static java.lang.System.getenv;
+
 /**
  * Abstract git flow mojo.
  * 
@@ -122,12 +124,12 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
      * The path to the Maven executable. Defaults to "mvn".
      */
     @Parameter(property = "mvnExecutable")
-    private String mvnExecutable;
+    private String mvnExecutable = getenv("mvnExecutable");
     /**
      * The path to the Git executable. Defaults to "git".
      */
     @Parameter(property = "gitExecutable")
-    private String gitExecutable;
+    private String gitExecutable = getenv("gitExecutable");
 
     /** Maven session. */
     @Component


### PR DESCRIPTION
#### Use case: 

If you have the plugin in a parent pom used by multiple diff applications, locally devs on Windows have the freedom to have the Maven binaries where they please so you do not want to set executables in the parent pom. Having to specify `mvnExecutable` every time on the command line can be inconvenient but we can have a seamless alternative.

#### Proposed Solution:

In Git Bash (and this can be used even on *nix to override the PATH) you can specify the executable in the env e.g. `export mvnExecutable=/c/path_to_m2_home/bin/mvn.bat`. This would be the default which can be overridden by `-DmvnExecutable=...`. When the env variable is not set the code behaves as it is does before the change.
 
- Also added .idea to .gitignore for Intellij contributors.