### PR TITLE
introduce new skipMvnDeploy goal option to support automatical art…

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,8 +131,12 @@ Note that although `${project.version}` can be used, any changes to version intr
 
 ## Additional goal parameters
 
-The `gitflow:release-finish`, `gitflow:release` and `gitflow:hotfix-finish` goals have `skipTag` parameter. This parameter controls whether the release/hotfix will be tagged in Git.
+The `gitflow:release-finish`, `gitflow:release` and `gitflow:hotfix-finish` goals have `skipTag` and `skipMvnDeploy` parameters:
+- `skipTag` controls whether the release/hotfix will be tagged in Git.
 The default value is `false` (i.e. the release/hotfix will be tagged).
+- `skipMvnDeploy` controls whether created Git tag will be deployed to nexus.
+Note deployment also requires `skipTag=true`, since only tags get deployed.
+Default value is `true` (i.e. maven artifact won't be deployed).
 
 The `gitflow:feature-start` goal has `skipFeatureVersion` parameter which controls whether the feature name will be appended to the project version or not.
 The default value is `false` (e.g. if the project version is `1.0.0-SNAPSHOT` and feature name is `feature_name` then after the execution it will be `1.0.0-feature_name-SNAPSHOT`).

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
@@ -40,9 +40,9 @@ import org.codehaus.plexus.util.cli.Commandline;
 
 /**
  * Abstract git flow mojo.
- * 
+ *
  * @author Aleksandr Mashchenko
- * 
+ *
  */
 public abstract class AbstractGitFlowMojo extends AbstractMojo {
     /** A full name of the versions-maven-plugin set goal. */
@@ -67,7 +67,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Git commit messages.
-     * 
+     *
      * @since 1.2.1
      */
     @Parameter(defaultValue = "${commitMessages}")
@@ -75,7 +75,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Whether this is Tycho build.
-     * 
+     *
      * @since 1.1.0
      */
     @Parameter(defaultValue = "false")
@@ -83,7 +83,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Whether to call Maven install goal during the mojo execution.
-     * 
+     *
      * @since 1.0.5
      */
     @Parameter(property = "installProject", defaultValue = "false")
@@ -91,7 +91,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Whether to allow SNAPSHOT versions in dependencies.
-     * 
+     *
      * @since 1.2.2
      */
     @Parameter(property = "allowSnapshots", defaultValue = "false")
@@ -99,7 +99,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Whether to fetch remote branch and compare it with the local one.
-     * 
+     *
      * @since 1.3.0
      */
     @Parameter(property = "fetchRemote", defaultValue = "true")
@@ -107,7 +107,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Whether to push to the remote.
-     * 
+     *
      * @since 1.3.0
      */
     @Parameter(property = "pushRemote", defaultValue = "true")
@@ -115,7 +115,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Whether to print commands output into the console.
-     * 
+     *
      * @since 1.0.7
      */
     @Parameter(property = "verbose", defaultValue = "false")
@@ -144,7 +144,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Initializes command line executables.
-     * 
+     *
      */
     private void initExecutables() {
         if (StringUtils.isBlank(cmdMvn.getExecutable())) {
@@ -163,7 +163,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Gets current project version from pom.xml file.
-     * 
+     *
      * @return Current project version.
      * @throws MojoFailureException
      */
@@ -194,7 +194,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Compares the production branch name with the development branch name.
-     * 
+     *
      * @return <code>true</code> if the production branch name is different from
      *         the development branch name, <code>false</code> otherwise.
      */
@@ -205,7 +205,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Checks uncommitted changes.
-     * 
+     *
      * @throws MojoFailureException
      * @throws CommandLineException
      */
@@ -251,7 +251,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Checks if branch name is acceptable.
-     * 
+     *
      * @param branchName
      *            Branch name to check.
      * @return <code>true</code> when name is valid, <code>false</code>
@@ -268,7 +268,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Validates version.
-     * 
+     *
      * @param version
      *            Version to validate.
      * @return <code>true</code> when version is valid, <code>false</code>
@@ -290,7 +290,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git commands to check for uncommitted changes.
-     * 
+     *
      * @return <code>true</code> when there are uncommitted changes,
      *         <code>false</code> otherwise.
      * @throws CommandLineException
@@ -332,7 +332,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git config commands to set Git Flow configuration.
-     * 
+     *
      * @throws MojoFailureException
      * @throws CommandLineException
      */
@@ -359,7 +359,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git config command.
-     * 
+     *
      * @param name
      *            Option name.
      * @param value
@@ -379,7 +379,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git for-each-ref with <code>refname:short</code> format.
-     * 
+     *
      * @param branchName
      *            Branch name to find.
      * @param firstMatch
@@ -414,7 +414,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Checks if local branch with given name exists.
-     * 
+     *
      * @param branchName
      *            Name of the branch to check.
      * @return <code>true</code> if local branch exists, <code>false</code>
@@ -431,22 +431,22 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git checkout.
-     * 
-     * @param branchName
-     *            Branch name to checkout.
+     *
+     * @param gitRef
+     *            git reference (eg branch/tag) to checkout.
      * @throws MojoFailureException
      * @throws CommandLineException
      */
-    protected void gitCheckout(final String branchName)
+    protected void gitCheckout(final String gitRef)
             throws MojoFailureException, CommandLineException {
-        getLog().info("Checking out '" + branchName + "' branch.");
+        getLog().info("Checking out " + gitRef);
 
-        executeGitCommand("checkout", branchName);
+        executeGitCommand("checkout", gitRef);
     }
 
     /**
      * Executes git checkout -b.
-     * 
+     *
      * @param newBranchName
      *            Create branch with this name.
      * @param fromBranchName
@@ -466,7 +466,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git commit -a -m.
-     * 
+     *
      * @param message
      *            Commit message.
      * @throws MojoFailureException
@@ -481,7 +481,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git rebase or git merge --no-ff or git merge.
-     * 
+     *
      * @param branchName
      *            Branch name to merge.
      * @param rebase
@@ -513,7 +513,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git merge --no-ff.
-     * 
+     *
      * @param branchName
      *            Branch name to merge.
      * @throws MojoFailureException
@@ -526,7 +526,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git merge --squash.
-     * 
+     *
      * @param branchName
      *            Branch name to merge.
      * @throws MojoFailureException
@@ -540,7 +540,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git tag -a -m.
-     * 
+     *
      * @param tagName
      *            Name of the tag.
      * @param message
@@ -557,7 +557,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git branch -d.
-     * 
+     *
      * @param branchName
      *            Branch name to delete.
      * @throws MojoFailureException
@@ -572,7 +572,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git branch -D.
-     * 
+     *
      * @param branchName
      *            Branch name to delete.
      * @throws MojoFailureException
@@ -586,8 +586,21 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
     }
 
     /**
+     * Returns the git branch we're currently on.
+     *
+     * @return git branch name we're currently on
+     * @throws MojoFailureException
+     * @throws CommandLineException
+     */
+    protected String gitBranchGet()
+            throws MojoFailureException, CommandLineException {
+
+        return executeGitCommandReturn("rev-parse", "--abbrev-ref", "HEAD");
+    }
+
+    /**
      * Fetches and checkouts from remote if local branch doesn't exist.
-     * 
+     *
      * @param branchName
      *            Branch name to check.
      * @throws MojoFailureException
@@ -609,7 +622,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git fetch and compares local branch with the remote.
-     * 
+     *
      * @param branchName
      *            Branch name to fetch and compare.
      * @throws MojoFailureException
@@ -640,7 +653,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git fetch.
-     * 
+     *
      * @param branchName
      *            Branch name to fetch.
      * @return <code>true</code> if git fetch returned success exit code,
@@ -673,7 +686,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
     /**
      * Executes git push, optionally with the <code>--follow-tags</code>
      * argument.
-     * 
+     *
      * @param branchName
      *            Branch name to push.
      * @param pushTags
@@ -700,7 +713,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
     /**
      * Executes 'set' goal of versions-maven-plugin or 'set-version' of
      * tycho-versions-plugin in case it is tycho build.
-     * 
+     *
      * @param version
      *            New version to set.
      * @throws MojoFailureException
@@ -721,7 +734,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes mvn clean test.
-     * 
+     *
      * @throws MojoFailureException
      * @throws CommandLineException
      */
@@ -737,7 +750,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes mvn clean install.
-     * 
+     *
      * @throws MojoFailureException
      * @throws CommandLineException
      */
@@ -749,8 +762,25 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
     }
 
     /**
+     * Checks out given {@code tagVersion}, executes mvn deploy & finally
+     * checks out the previous branch again.
+     *
+     * @throws MojoFailureException
+     * @throws CommandLineException
+     */
+    protected void mvnDeploy(String tagVersion) throws MojoFailureException,
+            CommandLineException {
+        getLog().info( String.format( "Deploying tag '%s' to nexus", tagVersion));
+        final String currentBranch = gitBranchGet();
+
+        gitCheckout(tagVersion);
+        executeMvnCommand("deploy");
+        gitCheckout(currentBranch);
+    }
+
+    /**
      * Executes Git command and returns output.
-     * 
+     *
      * @param args
      *            Git command line arguments.
      * @return Command output.
@@ -764,7 +794,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes Git command without failing on non successful exit code.
-     * 
+     *
      * @param args
      *            Git command line arguments.
      * @return Command result.
@@ -778,7 +808,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes Git command.
-     * 
+     *
      * @param args
      *            Git command line arguments.
      * @throws CommandLineException
@@ -791,7 +821,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes Maven command.
-     * 
+     *
      * @param args
      *            Maven command line arguments.
      * @throws CommandLineException
@@ -804,7 +834,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes command line.
-     * 
+     *
      * @param cmd
      *            Command line.
      * @param failOnError


### PR DESCRIPTION
…ifact deployments.

  note the option still depends on skipTag, as only tags can be deployed.


The deployment is always done as the last step to ensure broken tags don't get deployed to mvn repo.

`skipMvnDeploy` defaults to `true` as not to break backwards compatibility, but I'd like you to consider opposite default value.