### PR TITLE
Update versions of all modules in "-start" goals

### DIFF
--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
@@ -714,8 +714,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
             executeMvnCommand(TYCHO_VERSIONS_PLUGIN_SET_GOAL, "-DnewVersion="
                     + version, "-Dtycho.mode=maven");
         } else {
-            executeMvnCommand(VERSIONS_MAVEN_PLUGIN_SET_GOAL, "-B -DgroupId=\"*\" -DartifactId=\"*\" -DnewVersion="
-                    + version, "-DgenerateBackupPoms=false");
+            executeMvnCommand(VERSIONS_MAVEN_PLUGIN_SET_GOAL, "-B", "-DgroupId=\"*\"", "-DartifactId=\"*\"", "-DnewVersion=" + version, "-DgenerateBackupPoms=false");
         }
     }
 

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
@@ -714,7 +714,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
             executeMvnCommand(TYCHO_VERSIONS_PLUGIN_SET_GOAL, "-DnewVersion="
                     + version, "-Dtycho.mode=maven");
         } else {
-            executeMvnCommand(VERSIONS_MAVEN_PLUGIN_SET_GOAL, "-DgroupId=\"*\" -DartifactID=\"*\" -DnewVersion="
+            executeMvnCommand(VERSIONS_MAVEN_PLUGIN_SET_GOAL, "-B -DgroupId=\"*\" -DartifactId=\"*\" -DnewVersion="
                     + version, "-DgenerateBackupPoms=false");
         }
     }

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
@@ -714,7 +714,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
             executeMvnCommand(TYCHO_VERSIONS_PLUGIN_SET_GOAL, "-DnewVersion="
                     + version, "-Dtycho.mode=maven");
         } else {
-            executeMvnCommand(VERSIONS_MAVEN_PLUGIN_SET_GOAL, "-B", "-DgroupId=\"*\"", "-DartifactId=\"*\"", "-DnewVersion=" + version, "-DgenerateBackupPoms=false");
+            executeMvnCommand(VERSIONS_MAVEN_PLUGIN_SET_GOAL, "-B", "-DgroupId=*", "-DartifactId=*", "-DnewVersion=" + version, "-DgenerateBackupPoms=false");
         }
     }
 

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
@@ -714,7 +714,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
             executeMvnCommand(TYCHO_VERSIONS_PLUGIN_SET_GOAL, "-DnewVersion="
                     + version, "-Dtycho.mode=maven");
         } else {
-            executeMvnCommand(VERSIONS_MAVEN_PLUGIN_SET_GOAL, "-DnewVersion="
+            executeMvnCommand(VERSIONS_MAVEN_PLUGIN_SET_GOAL, "-DgroupId=\"*\" -DartifactID=\"*\" -DnewVersion="
                     + version, "-DgenerateBackupPoms=false");
         }
     }


### PR DESCRIPTION
Using -DgroupId="*" and -DartifactId="*" when calling "versions:set" will update the versions of all modules in a multi-module project.

NOTE: there might be issues when running "-start" goals on a project *somewhere inside* the project hierarchy, but I'm not sure that's common, since you usually want to release the whole repository...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aleksandr-m/gitflow-maven-plugin/49)
<!-- Reviewable:end -->
