### PR TITLE
releaseMergeFFOnly is not used when merging release to develop.

### DIFF
--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowReleaseFinishMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowReleaseFinishMojo.java
@@ -195,7 +195,7 @@ public class GitFlowReleaseFinishMojo extends AbstractGitFlowMojo {
                 gitCheckout(gitFlowConfig.getDevelopmentBranch());
 
                 gitMerge(releaseBranch, releaseRebase, releaseMergeNoFF,
-                        releaseMergeFFOnly);
+                        false);
             }
 
             // get next snapshot version


### PR DESCRIPTION
Typically the develop branch moves on while the release is being prepared. Therefore it does not make sense to require the use of fast-forward when merging to the develop branch.

On the master branch, however, it is useful to be able to require the use of fast-forward to make sure that the final commit on the release branch ends up in the master branch unmodified.