### PR TITLE
release-start can now commit the next SNAPSHOT version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ The `gitflow:release-finish` and `gitflow:release` goals have `versionDigitToInc
 For example, if the release version is `1.2.3.4` and `versionDigitToIncrement` is set to `1` then the next development version will be `1.3.0.0-SNAPSHOT`.
 If not set or set to not valid value defaults to increment last digit in the version.
 
+The `gitflow:release-start` and `gitflow:release-finish` have `commitDevelopmentVersionAtStart` parameter which controls whether the next development version is set and committed at start or after finish. By default the value is `false` which means that the next development version is set on the development branch after the release branch has been merged onto the development branch when finishing the release. This has the benefit of being able to easily cancel the release process simply by deleting the release branch. If the value is `true` then versioning happens on `gitflow:release-start`. First the project version is set to the release version on the development branch and the release branch is created. Then the development branch is set to the next development version. This allows the development branch to continue immediately with a new version and helps avoid any future merge conflicts related to project versioning.
+
 ### Remote interaction
 
 At the start of the each goal remote branch(es) will be fetched and compared with the local branch(es). If the local branch doesn't exist it will be checked out from the remote.

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
@@ -430,7 +430,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git checkout -b.
-     * 
+     *
      * @param newBranchName
      *            Create branch with this name.
      * @param fromBranchName
@@ -446,6 +446,25 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
                         + fromBranchName + "' and checking it out.");
 
         executeGitCommand("checkout", "-b", newBranchName, fromBranchName);
+    }
+
+    /**
+     * Executes git branch.
+     *
+     * @param newBranchName
+     *            Create branch with this name.
+     * @param fromBranchName
+     *            Create branch from this branch.
+     * @throws MojoFailureException
+     * @throws CommandLineException
+     */
+    protected void gitCreateBranch(final String newBranchName, final String fromBranchName)
+            throws MojoFailureException, CommandLineException {
+        getLog().info(
+                "Creating a new branch '" + newBranchName + "' from '"
+                        + fromBranchName + "'.");
+
+        executeGitCommand("branch", newBranchName, fromBranchName);
     }
 
     /**

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowReleaseStartMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowReleaseStartMojo.java
@@ -189,7 +189,9 @@ public class GitFlowReleaseStartMojo extends AbstractGitFlowMojo {
             }
 
             if (pushRemote) {
-                gitPush(gitFlowConfig.getDevelopmentBranch(), false);
+                if (commitDevelopmentVersionAtStart) {
+                    gitPush(gitFlowConfig.getDevelopmentBranch(), false);
+                }
 
                 gitPush(branchName, false);
             }

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowReleaseStartMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowReleaseStartMojo.java
@@ -65,11 +65,46 @@ public class GitFlowReleaseStartMojo extends AbstractGitFlowMojo {
 
     /**
      * Whether to push to the remote.
-     * 
+     *
      * @since 1.6.0
      */
     @Parameter(property = "pushRemote", defaultValue = "false")
     private boolean pushRemote;
+
+    /**
+     * Whether to commit development version when starting the release
+     * (vs when finishing the release which is the default).
+     *
+     * @since 1.7.0
+     */
+    @Parameter(property = "commitDevelopmentVersionAtStart", defaultValue = "false")
+    private boolean commitDevelopmentVersionAtStart;
+
+    /**
+     * Whether to remove qualifiers from the next development version.
+     *
+     * @since 1.7.0
+     */
+    @Parameter(property = "digitsOnlyDevVersion", defaultValue = "false")
+    private boolean digitsOnlyDevVersion = false;
+
+    /**
+     * Development version to use instead of the default next development
+     * version in non interactive mode.
+     *
+     * @since 1.7.0
+     */
+    @Parameter(property = "developmentVersion", defaultValue = "")
+    private String developmentVersion = "";
+
+    /**
+     * Which digit to increment in the next development version. Starts from
+     * zero.
+     *
+     * @since 1.7.0
+     */
+    @Parameter(property = "versionDigitToIncrement")
+    private Integer versionDigitToIncrement;
 
     /** {@inheritDoc} */
     @Override
@@ -99,8 +134,7 @@ public class GitFlowReleaseStartMojo extends AbstractGitFlowMojo {
             }
 
             // need to be in develop to check snapshots and to get
-            // correct
-            // project version
+            // correct project version
             gitCheckout(gitFlowConfig.getDevelopmentBranch());
 
             // check snapshots dependencies
@@ -108,63 +142,45 @@ public class GitFlowReleaseStartMojo extends AbstractGitFlowMojo {
                 checkSnapshotDependencies();
             }
 
-            // get current project version from pom
-            final String currentVersion = getCurrentProjectVersion();
+            // get release version
+            final String releaseVersion = getReleaseVersion();
 
-            String defaultVersion = null;
-            if (tychoBuild) {
-                defaultVersion = currentVersion;
-            } else {
-                // get default release version
-                defaultVersion = new GitFlowVersionInfo(currentVersion)
-                        .getReleaseVersionString();
-            }
-
-            if (defaultVersion == null) {
-                throw new MojoFailureException(
-                        "Cannot get default project version.");
-            }
-
-            String version = null;
-            if (settings.isInteractiveMode()) {
-                try {
-                    while (version == null) {
-                        version = prompter.prompt("What is release version? ["
-                                + defaultVersion + "]");
-
-                        if (!"".equals(version)
-                                && (!GitFlowVersionInfo.isValidVersion(version) || !validBranchName(version))) {
-                            getLog().info("The version is not valid.");
-                            version = null;
-                        }
-                    }
-                } catch (PrompterException e) {
-                    getLog().error(e);
-                }
-            } else {
-                version = releaseVersion;
-            }
-
-            if (StringUtils.isBlank(version)) {
-                version = defaultVersion;
-            }
-
+            // get release branch
             String branchName = gitFlowConfig.getReleaseBranchPrefix();
             if (!sameBranchName) {
-                branchName += version;
+                branchName += releaseVersion;
             }
 
-            // git checkout -b release/... develop
-            gitCreateAndCheckout(branchName,
-                    gitFlowConfig.getDevelopmentBranch());
+            if (commitDevelopmentVersionAtStart) {
+                // mvn versions:set ...
+                // git commit -a -m ...
+                commitProjectVersion(releaseVersion,
+                        commitMessages.getReleaseStartMessage());
 
-            // execute if version changed
-            if (!version.equals(currentVersion)) {
-                // mvn versions:set -DnewVersion=... -DgenerateBackupPoms=false
-                mvnSetVersions(version);
+                // git branch release/... develop
+                gitCreateBranch(branchName,
+                        gitFlowConfig.getDevelopmentBranch());
 
-                // git commit -a -m updating versions for release
-                gitCommit(commitMessages.getReleaseStartMessage());
+                final String nextSnapshotVersion =
+                        getNextSnapshotVersion(releaseVersion);
+
+                // mvn versions:set ...
+                // git commit -a -m ...
+                commitProjectVersion(nextSnapshotVersion,
+                        commitMessages.getReleaseFinishMessage());
+
+                // git checkout release/...
+                gitCheckout(branchName);
+            }
+            else {
+                // git checkout -b release/... develop
+                gitCreateAndCheckout(branchName,
+                        gitFlowConfig.getDevelopmentBranch());
+
+                // mvn versions:set ...
+                // git commit -a -m ...
+                commitProjectVersion(releaseVersion,
+                        commitMessages.getReleaseStartMessage());
             }
 
             if (installProject) {
@@ -173,12 +189,96 @@ public class GitFlowReleaseStartMojo extends AbstractGitFlowMojo {
             }
 
             if (pushRemote) {
+                gitPush(gitFlowConfig.getDevelopmentBranch(), false);
+
                 gitPush(branchName, false);
             }
         } catch (CommandLineException e) {
             getLog().error(e);
         } catch (VersionParseException e) {
             getLog().error(e);
+        }
+    }
+
+    private String getNextSnapshotVersion(String currentVersion) throws MojoFailureException, VersionParseException {
+        // get next snapshot version
+        final String nextSnapshotVersion;
+        if (!settings.isInteractiveMode()
+                && StringUtils.isNotBlank(developmentVersion)) {
+            nextSnapshotVersion = developmentVersion;
+        } else {
+            GitFlowVersionInfo versionInfo = new GitFlowVersionInfo(
+                    currentVersion);
+            if (digitsOnlyDevVersion) {
+                versionInfo = versionInfo.digitsVersionInfo();
+            }
+
+            nextSnapshotVersion = versionInfo
+                    .nextSnapshotVersion(versionDigitToIncrement);
+        }
+
+        if (StringUtils.isBlank(nextSnapshotVersion)) {
+            throw new MojoFailureException(
+                    "Next snapshot version is blank.");
+        }
+        return nextSnapshotVersion;
+    }
+
+    private String getReleaseVersion() throws MojoFailureException, VersionParseException, CommandLineException {
+        // get current project version from pom
+        final String currentVersion = getCurrentProjectVersion();
+
+        String defaultVersion = null;
+        if (tychoBuild) {
+            defaultVersion = currentVersion;
+        } else {
+            // get default release version
+            defaultVersion = new GitFlowVersionInfo(currentVersion)
+                    .getReleaseVersionString();
+        }
+
+        if (defaultVersion == null) {
+            throw new MojoFailureException(
+                    "Cannot get default project version.");
+        }
+
+        String version = null;
+        if (settings.isInteractiveMode()) {
+            try {
+                while (version == null) {
+                    version = prompter.prompt("What is release version? ["
+                            + defaultVersion + "]");
+
+                    if (!"".equals(version)
+                            && (!GitFlowVersionInfo.isValidVersion(version) || !validBranchName(version))) {
+                        getLog().info("The version is not valid.");
+                        version = null;
+                    }
+                }
+            } catch (PrompterException e) {
+                getLog().error(e);
+            }
+        } else {
+            version = releaseVersion;
+        }
+
+        if (StringUtils.isBlank(version)) {
+            version = defaultVersion;
+        }
+
+        return version;
+    }
+
+    private void commitProjectVersion(String version, String commitMessage)
+            throws CommandLineException, MojoFailureException {
+        // execute if version changed
+        String currentVersion = getCurrentProjectVersion();
+        if (!version.equals(currentVersion)) {
+            // mvn versions:set -DnewVersion=... -DgenerateBackupPoms=false
+            mvnSetVersions(version);
+
+            // git commit -a -m commitMessage
+            gitCommit(commitMessage);
         }
     }
 }


### PR DESCRIPTION
This change enables the development to continue with the next version on the develop branch after the release process has been started. For example if you're releasing version 1.0, the develop branch can be set to 1.1-SNAPSHOT while finalizing the release branch of 1.0.