### PR TITLE
Allow custom commit messages when merge-squashing feature branches

### DIFF
--- a/src/it/feature-finish-it-2/expected-pom.xml
+++ b/src/it/feature-finish-it-2/expected-pom.xml
@@ -1,0 +1,7 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.amashchenko.maven.plugin</groupId>
+    <artifactId>gitflow-maven-test</artifactId>
+    <packaging>pom</packaging>
+    <version>0.0.3-SNAPSHOT</version>
+</project>

--- a/src/it/feature-finish-it-2/gitignorefile
+++ b/src/it/feature-finish-it-2/gitignorefile
@@ -1,0 +1,5 @@
+build.log
+expected-pom.xml
+invoker.properties
+init.bsh
+verify.bsh

--- a/src/it/feature-finish-it-2/init.bsh
+++ b/src/it/feature-finish-it-2/init.bsh
@@ -1,0 +1,23 @@
+try {
+    new File(basedir, "gitignorefile").renameTo(new File(basedir, ".gitignore"));
+
+    Process p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " init");
+    p.waitFor();
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " add .");
+    p.waitFor();
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " commit -m init");
+    p.waitFor();
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " branch feature/test");
+    p.waitFor();
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " checkout -b develop");
+    p.waitFor();
+
+} catch (Exception e) {
+    e.printStackTrace();
+    return false;
+}
+return true;

--- a/src/it/feature-finish-it-2/invoker.properties
+++ b/src/it/feature-finish-it-2/invoker.properties
@@ -1,0 +1,3 @@
+invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:feature-finish -DpushRemote=false -B -DfeatureName=test -DfeatureSquash=true -DcommitMessage="custom commit message"
+
+invoker.description=Non-interactive feature-finish.

--- a/src/it/feature-finish-it-2/pom.xml
+++ b/src/it/feature-finish-it-2/pom.xml
@@ -1,0 +1,7 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.amashchenko.maven.plugin</groupId>
+    <artifactId>gitflow-maven-test</artifactId>
+    <packaging>pom</packaging>
+    <version>0.0.3-test-SNAPSHOT</version>
+</project>

--- a/src/it/feature-finish-it-2/verify.bsh
+++ b/src/it/feature-finish-it-2/verify.bsh
@@ -13,6 +13,9 @@ try {
     String actual = FileUtils.fileRead(file, "UTF-8");
     String expected = FileUtils.fileRead(expectedFile, "UTF-8");
 
+    actual = actual.replaceAll("\\r?\\n", "");
+    expected = expected.replaceAll("\\r?\\n", "");
+
     if (!expected.equals(actual)) {
         System.out.println("feature-finish expected: " + expected + " actual was:" + actual);
         return false;
@@ -20,8 +23,8 @@ try {
 
     File logFile = new File(basedir, "build.log");
     String log = FileUtils.fileRead(logFile, "UTF-8");
-    if (!log.contains("Committing changes with message: custom commit message")) {
-        System.out.println("feature-finish build.log does not contain expected commit message: 'custom commit message'");
+    if (!log.contains("feature/test: custom commit message")) {
+        System.out.println("feature-finish build.log does not contain expected commit message: 'feature/test: custom commit message'");
         return false;
     }
 

--- a/src/it/feature-finish-it-2/verify.bsh
+++ b/src/it/feature-finish-it-2/verify.bsh
@@ -1,0 +1,32 @@
+import org.codehaus.plexus.util.FileUtils;
+
+try {
+    File gitRef = new File(basedir, ".git/refs/heads/feature/test");
+    if (gitRef.exists()) {
+        System.out.println("feature-finish .git/refs/heads/feature/test exists");
+        return false;
+    }
+
+    File file = new File(basedir, "pom.xml");
+    File expectedFile = new File(basedir, "expected-pom.xml");
+
+    String actual = FileUtils.fileRead(file, "UTF-8");
+    String expected = FileUtils.fileRead(expectedFile, "UTF-8");
+
+    if (!expected.equals(actual)) {
+        System.out.println("feature-finish expected: " + expected + " actual was:" + actual);
+        return false;
+    }
+
+    File logFile = new File(basedir, "build.log");
+    String log = FileUtils.fileRead(logFile, "UTF-8");
+    if (!log.contains("Committing changes with message: custom commit message")) {
+        System.out.println("feature-finish build.log does not contain expected commit message: 'custom commit message'");
+        return false;
+    }
+
+} catch (Exception e) {
+    e.printStackTrace();
+    return false;
+}
+return true;

--- a/src/it/feature-start-it/verify.bsh
+++ b/src/it/feature-start-it/verify.bsh
@@ -13,6 +13,9 @@ try {
     String actual = FileUtils.fileRead(file, "UTF-8");
     String expected = FileUtils.fileRead(expectedFile, "UTF-8");
 
+    actual = actual.replaceAll("\\r?\\n", "");
+    expected = expected.replaceAll("\\r?\\n", "");
+
     if (!expected.equals(actual)) {
         System.out.println("feature-start expected: " + expected + " actual was:" + actual);
         return false;

--- a/src/it/hotfix-start-2-it/verify.bsh
+++ b/src/it/hotfix-start-2-it/verify.bsh
@@ -13,6 +13,9 @@ try {
     String actual = FileUtils.fileRead(file, "UTF-8");
     String expected = FileUtils.fileRead(expectedFile, "UTF-8");
 
+    actual = actual.replaceAll("\\r?\\n", "");
+    expected = expected.replaceAll("\\r?\\n", "");
+
     if (!expected.equals(actual)) {
         System.out.println("hotfix-start expected: " + expected + " actual was:" + actual);
         return false;

--- a/src/it/hotfix-start-it/verify.bsh
+++ b/src/it/hotfix-start-it/verify.bsh
@@ -13,6 +13,9 @@ try {
     String actual = FileUtils.fileRead(file, "UTF-8");
     String expected = FileUtils.fileRead(expectedFile, "UTF-8");
 
+    actual = actual.replaceAll("\\r?\\n", "");
+    expected = expected.replaceAll("\\r?\\n", "");
+
     if (!expected.equals(actual)) {
         System.out.println("hotfix-start expected: " + expected + " actual was:" + actual);
         return false;

--- a/src/it/release-finish-2-it/verify.bsh
+++ b/src/it/release-finish-2-it/verify.bsh
@@ -29,6 +29,9 @@ try {
     String actual = FileUtils.fileRead(file, "UTF-8");
     String expected = FileUtils.fileRead(expectedFile, "UTF-8");
 
+    actual = actual.replaceAll("\\r?\\n", "");
+    expected = expected.replaceAll("\\r?\\n", "");
+
     if (!expected.equals(actual)) {
         System.out.println("release-finish develop expected: " + expected + " actual was:" + actual);
         return false;
@@ -43,6 +46,9 @@ try {
     actual = FileUtils.fileRead(file, "UTF-8");
     expected = FileUtils.fileRead(expectedFile, "UTF-8");
 
+    actual = actual.replaceAll("\\r?\\n", "");
+    expected = expected.replaceAll("\\r?\\n", "");
+
     if (!expected.equals(actual)) {
         System.out.println("release-finish master expected: " + expected + " actual was:" + actual);
         return false;
@@ -53,6 +59,7 @@ try {
 
     file = new File(basedir, "pom.xml");
     actual = FileUtils.fileRead(file, "UTF-8");
+    actual = actual.replaceAll("\\r?\\n", "");
     if (!expected.equals(actual)) {
         System.out.println("release-finish release expected: " + expected + " actual was:" + actual);
         return false;

--- a/src/it/release-finish-3-it/verify.bsh
+++ b/src/it/release-finish-3-it/verify.bsh
@@ -29,6 +29,9 @@ try {
     String actual = FileUtils.fileRead(file, "UTF-8");
     String expected = FileUtils.fileRead(expectedFile, "UTF-8");
 
+    actual = actual.replaceAll("\\r?\\n", "");
+    expected = expected.replaceAll("\\r?\\n", "");
+
     if (!expected.equals(actual)) {
         System.out.println("release-finish expected: " + expected + " actual was:" + actual);
         return false;
@@ -42,6 +45,9 @@ try {
 
     actual = FileUtils.fileRead(file, "UTF-8");
     expected = FileUtils.fileRead(expectedFile, "UTF-8");
+
+    actual = actual.replaceAll("\\r?\\n", "");
+    expected = expected.replaceAll("\\r?\\n", "");
 
     if (!expected.equals(actual)) {
         System.out.println("release-finish expected: " + expected + " actual was:" + actual);

--- a/src/it/release-finish-4-it/verify.bsh
+++ b/src/it/release-finish-4-it/verify.bsh
@@ -29,6 +29,9 @@ try {
     String actual = FileUtils.fileRead(file, "UTF-8");
     String expected = FileUtils.fileRead(expectedFile, "UTF-8");
 
+    actual = actual.replaceAll("\\r?\\n", "");
+    expected = expected.replaceAll("\\r?\\n", "");
+
     if (!expected.equals(actual)) {
         System.out.println("release-finish expected: " + expected + " actual was:" + actual);
         return false;
@@ -42,6 +45,9 @@ try {
 
     actual = FileUtils.fileRead(file, "UTF-8");
     expected = FileUtils.fileRead(expectedFile, "UTF-8");
+
+    actual = actual.replaceAll("\\r?\\n", "");
+    expected = expected.replaceAll("\\r?\\n", "");
 
     if (!expected.equals(actual)) {
         System.out.println("release-finish expected: " + expected + " actual was:" + actual);

--- a/src/it/release-finish-5-it/verify.bsh
+++ b/src/it/release-finish-5-it/verify.bsh
@@ -29,6 +29,9 @@ try {
     String actual = FileUtils.fileRead(file, "UTF-8");
     String expected = FileUtils.fileRead(expectedFile, "UTF-8");
 
+    actual = actual.replaceAll("\\r?\\n", "");
+    expected = expected.replaceAll("\\r?\\n", "");
+
     if (!expected.equals(actual)) {
         System.out.println("release-finish expected: " + expected + " actual was:" + actual);
         return false;
@@ -42,6 +45,9 @@ try {
 
     actual = FileUtils.fileRead(file, "UTF-8");
     expected = FileUtils.fileRead(expectedFile, "UTF-8");
+
+    actual = actual.replaceAll("\\r?\\n", "");
+    expected = expected.replaceAll("\\r?\\n", "");
 
     if (!expected.equals(actual)) {
         System.out.println("release-finish expected: " + expected + " actual was:" + actual);

--- a/src/it/release-finish-it/verify.bsh
+++ b/src/it/release-finish-it/verify.bsh
@@ -29,6 +29,9 @@ try {
     String actual = FileUtils.fileRead(file, "UTF-8");
     String expected = FileUtils.fileRead(expectedFile, "UTF-8");
 
+    actual = actual.replaceAll("\\r?\\n", "");
+    expected = expected.replaceAll("\\r?\\n", "");
+
     if (!expected.equals(actual)) {
         System.out.println("release-finish expected: " + expected + " actual was:" + actual);
         return false;
@@ -42,6 +45,9 @@ try {
 
     actual = FileUtils.fileRead(file, "UTF-8");
     expected = FileUtils.fileRead(expectedFile, "UTF-8");
+
+    actual = actual.replaceAll("\\r?\\n", "");
+    expected = expected.replaceAll("\\r?\\n", "");
 
     if (!expected.equals(actual)) {
         System.out.println("release-finish expected: " + expected + " actual was:" + actual);

--- a/src/it/release-it/verify.bsh
+++ b/src/it/release-it/verify.bsh
@@ -29,6 +29,9 @@ try {
     String actual = FileUtils.fileRead(file, "UTF-8");
     String expected = FileUtils.fileRead(expectedFile, "UTF-8");
 
+    actual = actual.replaceAll("\\r?\\n", "");
+    expected = expected.replaceAll("\\r?\\n", "");
+
     if (!expected.equals(actual)) {
         System.out.println("release expected: " + expected + " actual was:" + actual);
         return false;
@@ -42,6 +45,9 @@ try {
 
     actual = FileUtils.fileRead(file, "UTF-8");
     expected = FileUtils.fileRead(expectedFile, "UTF-8");
+
+    actual = actual.replaceAll("\\r?\\n", "");
+    expected = expected.replaceAll("\\r?\\n", "");
 
     if (!expected.equals(actual)) {
         System.out.println("release expected: " + expected + " actual was:" + actual);

--- a/src/it/release-start-2-it/verify.bsh
+++ b/src/it/release-start-2-it/verify.bsh
@@ -13,6 +13,9 @@ try {
     String actual = FileUtils.fileRead(file, "UTF-8");
     String expected = FileUtils.fileRead(expectedFile, "UTF-8");
 
+    actual = actual.replaceAll("\\r?\\n", "");
+    expected = expected.replaceAll("\\r?\\n", "");
+
     if (!expected.equals(actual)) {
         System.out.println("release-start expected: " + expected + " actual was:" + actual);
         return false;

--- a/src/it/release-start-3-it/verify.bsh
+++ b/src/it/release-start-3-it/verify.bsh
@@ -13,6 +13,9 @@ try {
     String actual = FileUtils.fileRead(file, "UTF-8");
     String expected = FileUtils.fileRead(expectedFile, "UTF-8");
 
+    actual = actual.replaceAll("\\r?\\n", "");
+    expected = expected.replaceAll("\\r?\\n", "");
+
     if (!expected.equals(actual)) {
         System.out.println("release-start expected: " + expected + " actual was:" + actual);
         return false;

--- a/src/it/release-start-finish-it/verify.bsh
+++ b/src/it/release-start-finish-it/verify.bsh
@@ -30,6 +30,9 @@ try {
     String actual = FileUtils.fileRead(file, "UTF-8");
     String expected = FileUtils.fileRead(expectedFile, "UTF-8");
 
+    actual = actual.replaceAll("\\r?\\n", "");
+    expected = expected.replaceAll("\\r?\\n", "");
+
     if (!expected.equals(actual)) {
         System.out.println("release-start-finish expected: " + expected + " actual was:" + actual);
         return false;
@@ -57,6 +60,9 @@ try {
 
     actual = FileUtils.fileRead(file, "UTF-8");
     expected = FileUtils.fileRead(expectedFile, "UTF-8");
+
+    actual = actual.replaceAll("\\r?\\n", "");
+    expected = expected.replaceAll("\\r?\\n", "");
 
     if (!expected.equals(actual)) {
         System.out.println("release-start-finish expected: " + expected + " actual was:" + actual);

--- a/src/it/release-start-it/verify.bsh
+++ b/src/it/release-start-it/verify.bsh
@@ -13,6 +13,9 @@ try {
     String actual = FileUtils.fileRead(file, "UTF-8");
     String expected = FileUtils.fileRead(expectedFile, "UTF-8");
 
+    actual = actual.replaceAll("\\r?\\n", "");
+    expected = expected.replaceAll("\\r?\\n", "");
+
     if (!expected.equals(actual)) {
         System.out.println("release-start expected: " + expected + " actual was:" + actual);
         return false;

--- a/src/it/support-start-2-it/expected-pom.xml
+++ b/src/it/support-start-2-it/expected-pom.xml
@@ -1,0 +1,7 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.amashchenko.maven.plugin</groupId>
+    <artifactId>gitflow-maven-test</artifactId>
+    <packaging>pom</packaging>
+    <version>0.0.3</version>
+</project>

--- a/src/it/support-start-2-it/gitignorefile
+++ b/src/it/support-start-2-it/gitignorefile
@@ -1,0 +1,5 @@
+build.log
+expected-pom.xml
+invoker.properties
+init.bsh
+verify.bsh

--- a/src/it/support-start-2-it/init.bsh
+++ b/src/it/support-start-2-it/init.bsh
@@ -1,3 +1,5 @@
+import org.codehaus.plexus.util.FileUtils;
+
 try {
     new File(basedir, "gitignorefile").renameTo(new File(basedir, ".gitignore"));
 
@@ -10,10 +12,19 @@ try {
     p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " commit -m init");
     p.waitFor();
 
-    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " branch feature/test");
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " tag -a 0.0.3 -m 0.0.3");
     p.waitFor();
 
-    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " commit -a --allow-empty -m dummy");
+    File file = new File(basedir, "test.txt");
+    FileUtils.fileAppend(file.getPath(), "next commit");
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " add .");
+    p.waitFor();
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " commit -m next");
+    p.waitFor();
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " tag -a 0.0.4 -m 0.0.4");
     p.waitFor();
 
     p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " checkout -b develop");

--- a/src/it/support-start-2-it/invoker.properties
+++ b/src/it/support-start-2-it/invoker.properties
@@ -1,0 +1,3 @@
+invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:support-start -DpushRemote=false -B -DtagName=0.0.3
+
+invoker.description=Non-interactive support-start with tagName parameter.

--- a/src/it/support-start-2-it/pom.xml
+++ b/src/it/support-start-2-it/pom.xml
@@ -1,0 +1,7 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.amashchenko.maven.plugin</groupId>
+    <artifactId>gitflow-maven-test</artifactId>
+    <packaging>pom</packaging>
+    <version>0.0.3</version>
+</project>

--- a/src/it/support-start-2-it/verify.bsh
+++ b/src/it/support-start-2-it/verify.bsh
@@ -1,9 +1,9 @@
 import org.codehaus.plexus.util.FileUtils;
 
 try {
-    File gitRef = new File(basedir, ".git/refs/heads/feature/test");
-    if (gitRef.exists()) {
-        System.out.println("feature-finish .git/refs/heads/feature/test exists");
+    File gitRef = new File(basedir, ".git/refs/heads/support/0.0.3");
+    if (!gitRef.exists()) {
+        System.out.println("support-start .git/refs/heads/support/0.0.3 doesn't exist");
         return false;
     }
 
@@ -17,7 +17,7 @@ try {
     expected = expected.replaceAll("\\r?\\n", "");
 
     if (!expected.equals(actual)) {
-        System.out.println("feature-finish expected: " + expected + " actual was:" + actual);
+        System.out.println("support-start expected: " + expected + " actual was:" + actual);
         return false;
     }
 } catch (Exception e) {

--- a/src/it/support-start-it/expected-pom.xml
+++ b/src/it/support-start-it/expected-pom.xml
@@ -1,0 +1,7 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.amashchenko.maven.plugin</groupId>
+    <artifactId>gitflow-maven-test</artifactId>
+    <packaging>pom</packaging>
+    <version>0.0.3</version>
+</project>

--- a/src/it/support-start-it/gitignorefile
+++ b/src/it/support-start-it/gitignorefile
@@ -1,0 +1,5 @@
+build.log
+expected-pom.xml
+invoker.properties
+init.bsh
+verify.bsh

--- a/src/it/support-start-it/init.bsh
+++ b/src/it/support-start-it/init.bsh
@@ -1,3 +1,5 @@
+import org.codehaus.plexus.util.FileUtils;
+
 try {
     new File(basedir, "gitignorefile").renameTo(new File(basedir, ".gitignore"));
 
@@ -10,10 +12,19 @@ try {
     p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " commit -m init");
     p.waitFor();
 
-    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " branch feature/test");
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " tag -a 0.0.1 -m 0.0.1");
     p.waitFor();
 
-    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " commit -a --allow-empty -m dummy");
+    File file = new File(basedir, "test.txt");
+    FileUtils.fileAppend(file.getPath(), "next commit");
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " add .");
+    p.waitFor();
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " commit -m next");
+    p.waitFor();
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " tag -a 0.0.3 -m 0.0.3");
     p.waitFor();
 
     p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " checkout -b develop");

--- a/src/it/support-start-it/invoker.properties
+++ b/src/it/support-start-it/invoker.properties
@@ -1,0 +1,3 @@
+invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:support-start -DpushRemote=false -B
+
+invoker.description=Non-interactive simple support-start.

--- a/src/it/support-start-it/pom.xml
+++ b/src/it/support-start-it/pom.xml
@@ -1,0 +1,7 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.amashchenko.maven.plugin</groupId>
+    <artifactId>gitflow-maven-test</artifactId>
+    <packaging>pom</packaging>
+    <version>0.0.3</version>
+</project>

--- a/src/it/support-start-it/verify.bsh
+++ b/src/it/support-start-it/verify.bsh
@@ -1,9 +1,9 @@
 import org.codehaus.plexus.util.FileUtils;
 
 try {
-    File gitRef = new File(basedir, ".git/refs/heads/feature/test");
-    if (gitRef.exists()) {
-        System.out.println("feature-finish .git/refs/heads/feature/test exists");
+    File gitRef = new File(basedir, ".git/refs/heads/support/0.0.3");
+    if (!gitRef.exists()) {
+        System.out.println("support-start .git/refs/heads/support/0.0.3 doesn't exist");
         return false;
     }
 
@@ -17,7 +17,7 @@ try {
     expected = expected.replaceAll("\\r?\\n", "");
 
     if (!expected.equals(actual)) {
-        System.out.println("feature-finish expected: " + expected + " actual was:" + actual);
+        System.out.println("support-start expected: " + expected + " actual was:" + actual);
         return false;
     }
 } catch (Exception e) {

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
@@ -519,7 +519,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
      */
     protected void gitCommit(final String message) throws MojoFailureException,
             CommandLineException {
-        getLog().info("Committing changes.");
+        getLog().info("Committing changes with message: " + message);
 
         executeGitCommand("commit", "-a", "-m", message);
     }
@@ -538,7 +538,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
      */
     protected void gitCommit(String message, Map<String, String> map)
             throws MojoFailureException, CommandLineException {
-        getLog().info("Committing changes.");
+        getLog().info("Committing changes with message: " + message);
 
         if (map != null) {
             for (Entry<String, String> entr : map.entrySet()) {

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowFeatureFinishMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowFeatureFinishMojo.java
@@ -128,7 +128,7 @@ public class GitFlowFeatureFinishMojo extends AbstractGitFlowMojo {
                 // git merge --squash feature/...
                 setMergeSquashCommitMessage(featureBranchName);
                 gitMergeSquash(featureBranchName);
-                gitCommit(featureCommitMessage);
+                gitCommitAmend(featureCommitMessage);
             } else {
                 // git merge --no-ff feature/...
                 gitMergeNoff(featureBranchName);

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowFeatureFinishMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowFeatureFinishMojo.java
@@ -126,8 +126,9 @@ public class GitFlowFeatureFinishMojo extends AbstractGitFlowMojo {
 
             if (featureSquash) {
                 // git merge --squash feature/...
-                setCommitMessage();
+                setMergeSquashCommitMessage(featureBranchName);
                 gitMergeSquash(featureBranchName);
+                gitCommit(featureCommitMessage);
             } else {
                 // git merge --no-ff feature/...
                 gitMergeNoff(featureBranchName);
@@ -219,20 +220,22 @@ public class GitFlowFeatureFinishMojo extends AbstractGitFlowMojo {
         return featureBranchName;
     }
 
-    private void setCommitMessage() throws MojoFailureException, CommandLineException {
+    private void setMergeSquashCommitMessage(String branchName) throws MojoFailureException, CommandLineException {
 
         if (settings.isInteractiveMode()) {
             try {
                 while (StringUtils.isBlank(featureCommitMessage)) {
-                    featureCommitMessage = prompter.prompt("Enter a short merge commit message for '" + featureName + "'.", featureName);
+                    featureCommitMessage = prompter.prompt("Enter a short merge commit message for '" + branchName + "'.");
                 }
             } catch (PrompterException e) {
                 throw new MojoFailureException("feature-finish", e);
             }
         } else if (featureCommitMessage == null) {
-            featureCommitMessage = featureName;
+            featureCommitMessage = branchName;
         }
 
-        commitMessages.setFeatureFinishMessage(featureCommitMessage);
+        if (!featureCommitMessage.startsWith(branchName)) {
+            featureCommitMessage = branchName.concat(": ").concat(featureCommitMessage);
+        }
     }
 }

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowReleaseFinishMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowReleaseFinishMojo.java
@@ -143,6 +143,13 @@ public class GitFlowReleaseFinishMojo extends AbstractGitFlowMojo {
     @Parameter(property = "postReleaseGoals")
     private String postReleaseGoals;
 
+    /**
+     * Whether to make a GPG-signed tag.
+     * 
+     */
+    @Parameter(property = "gpgSignTag", defaultValue = "false")
+    private boolean gpgSignTag = false;
+
     /** {@inheritDoc} */
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
@@ -224,7 +231,7 @@ public class GitFlowReleaseFinishMojo extends AbstractGitFlowMojo {
 
                 // git tag -a ...
                 gitTag(gitFlowConfig.getVersionTagPrefix() + tagVersion,
-                        commitMessages.getTagReleaseMessage());
+                        commitMessages.getTagReleaseMessage(), gpgSignTag);
             }
 
             // maven goals after merge

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowReleaseMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowReleaseMojo.java
@@ -139,6 +139,13 @@ public class GitFlowReleaseMojo extends AbstractGitFlowMojo {
     @Parameter(property = "postReleaseGoals")
     private String postReleaseGoals;
 
+    /**
+     * Whether to make a GPG-signed tag.
+     * 
+     */
+    @Parameter(property = "gpgSignTag", defaultValue = "false")
+    private boolean gpgSignTag = false;
+
     /** {@inheritDoc} */
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
@@ -267,7 +274,7 @@ public class GitFlowReleaseMojo extends AbstractGitFlowMojo {
 
                 // git tag -a ...
                 gitTag(gitFlowConfig.getVersionTagPrefix() + version,
-                        commitMessages.getTagReleaseMessage());
+                        commitMessages.getTagReleaseMessage(), gpgSignTag);
             }
 
             // maven goals after release

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowSupportStartMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowSupportStartMojo.java
@@ -41,6 +41,13 @@ public class GitFlowSupportStartMojo extends AbstractGitFlowMojo {
     @Parameter(property = "pushRemote", defaultValue = "true")
     private boolean pushRemote;
 
+    /**
+     * Tag name to use in non-interactive mode.
+     *
+     */
+    @Parameter(property = "tagName")
+    private String tagName;
+
     /** {@inheritDoc} */
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
@@ -53,24 +60,39 @@ public class GitFlowSupportStartMojo extends AbstractGitFlowMojo {
             // check uncommitted changes
             checkUncommittedChanges();
 
-            // get tags
-            String tagsStr = gitFindTags();
+            String tag = null;
+            if (settings.isInteractiveMode()) {
+                // get tags
+                String tagsStr = gitFindTags();
 
-            if (StringUtils.isBlank(tagsStr)) {
-                throw new MojoFailureException("There are no tags.");
+                if (StringUtils.isBlank(tagsStr)) {
+                    throw new MojoFailureException("There are no tags.");
+                }
+
+                try {
+                    tag = prompter.prompt("Choose tag to start support branch",
+                            Arrays.asList(tagsStr.split("\\r?\\n")));
+                } catch (PrompterException e) {
+                    throw new MojoFailureException("support-start", e);
+                }
+            } else if (StringUtils.isNotBlank(tagName)) {
+                if (gitCheckTagExists(tagName)) {
+                    tag = tagName;
+                } else {
+                    throw new MojoFailureException("The tag '" + tagName + "' doesn't exist.");
+                }
+            } else {
+                getLog().info("The tagName is blank. Using the last tag.");
+                tag = gitFindLastTag();
             }
 
-            String tagName = null;
-            try {
-                tagName = prompter.prompt("Choose tag to start support branch",
-                        Arrays.asList(tagsStr.split("\\r?\\n")));
-            } catch (PrompterException e) {
-                throw new MojoFailureException("support-start", e);
+            if (StringUtils.isBlank(tag)) {
+                throw new MojoFailureException("Tag is blank.");
             }
 
             // git for-each-ref refs/heads/support/...
             final boolean supportBranchExists = gitCheckBranchExists(gitFlowConfig
-                    .getSupportBranchPrefix() + tagName);
+                    .getSupportBranchPrefix() + tag);
 
             if (supportBranchExists) {
                 throw new MojoFailureException(
@@ -78,8 +100,7 @@ public class GitFlowSupportStartMojo extends AbstractGitFlowMojo {
             }
 
             // git checkout -b ... tag
-            gitCreateAndCheckout(gitFlowConfig.getSupportBranchPrefix()
-                    + tagName, tagName);
+            gitCreateAndCheckout(gitFlowConfig.getSupportBranchPrefix() + tag, tag);
 
             if (installProject) {
                 // mvn clean install
@@ -87,7 +108,7 @@ public class GitFlowSupportStartMojo extends AbstractGitFlowMojo {
             }
 
             if (pushRemote) {
-                gitPush(gitFlowConfig.getSupportBranchPrefix() + tagName, false);
+                gitPush(gitFlowConfig.getSupportBranchPrefix() + tag, false);
             }
         } catch (CommandLineException e) {
             throw new MojoFailureException("support-start", e);

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -13,7 +13,7 @@
     <skin>
         <groupId>org.apache.maven.skins</groupId>
         <artifactId>maven-fluido-skin</artifactId>
-        <version>1.4</version>
+        <version>1.6</version>
     </skin>
 
     <custom>


### PR DESCRIPTION
**Purpose**
This PR allows a user to specify a custom commit message when merge-squashing feature branches using `mvn gitflow:feature-finish -DfeatureSquash=true`. It also fixes a bug in this flow which is described below.

**Rationale**
When using `git merge --squash feature/...` git will squash all commits on the feature branch, leaving the last commit message on the current branch as the single commit message after the merge. This commit message could be anything, and doesn't necessarily reflect the purpose of the feature branch. The existing method of adding a commit message of the feature branch name afterwards does not work as intended, so the commit message after the merge is essentially random.

**Usage**
From the command-line (interactive mode), to use the commit message "feature commit message" you would type:

```mvn gitflow:feature-finish -DfeatureSquash=true -DcommitMessage="feature commit message"```

If you don't specify the `-DcommitMessage` property you'll be prompted to enter one. 

The commit message text you specify will be appended to the feature name in the commit log, e.g. 

```
commit 402487d0c93f81cacf78eb65339ac2162e085f32
Author: Vince Bickers <vince@mambofish.org>
Date:   Sat Nov 25 16:29:50 2017 +0400

    feature/test: feature commit message
```

In non-interactive mode, the commit message will default to the feature branch name if not specified via the `-DcommandLine=...` property as described above.

**Behavioural changes and bugfix**
Currently, the GitFlowFeatureFinishMojo with the `featureSquash` property enabled attempts to create a commit message with the feature branch name after the merge has happened. In practice this commit always fails, because at this point there are no uncommitted files to be committed. Until recently, this failure was simply logged and the mojo completed successfully. Since then failure to execute a git command causes the mojo to fail. There are no integration tests for `featureSquash`, so this bug is not detected. The proposed behaviour corrects this issue.

The proposed behaviour amends the commit created by `git merge --squash` and replaces it with the commit message specified by the user. e.g.

```
git merge --squash feature/test
git commit --amend -m "feature/test: feature commit message"
```

