### PR TITLE
Bugfix: allow the use of the locally specified versions-maven-plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.9.1
+
+* Use the versions-maven-plugin version as specified by the pom in which this module is used instead of always 2.1
+
 ## v1.9.0
 
 * Fixed not failing the whole build on goals errors

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
@@ -45,7 +45,7 @@ import org.codehaus.plexus.util.cli.Commandline;
  */
 public abstract class AbstractGitFlowMojo extends AbstractMojo {
     /** A full name of the versions-maven-plugin set goal. */
-    private static final String VERSIONS_MAVEN_PLUGIN_SET_GOAL = "org.codehaus.mojo:versions-maven-plugin:2.1:set";
+    private static final String VERSIONS_MAVEN_PLUGIN_SET_GOAL = "org.codehaus.mojo:versions-maven-plugin:set";
     /** Name of the tycho-versions-plugin set-version goal. */
     private static final String TYCHO_VERSIONS_PLUGIN_SET_GOAL = "org.eclipse.tycho:tycho-versions-plugin:set-version";
 


### PR DESCRIPTION
We're trying to use a versions-maven-plugin property 'processAllModules' which became available at 2.5. Since your code explicitly uses 2.1 this fails because this property doesn't exist yet.
This bugfix fixes this problem by not explicitly depending on the 2.1 version of the versions-maven-plugin anymore.