### PR TITLE
Make useSnapshotIn* available from CLI

### DIFF
--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowHotfixFinishMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowHotfixFinishMojo.java
@@ -99,7 +99,7 @@ public class GitFlowHotfixFinishMojo extends AbstractGitFlowMojo {
      * 
      * @since 1.10.0
      */
-    @Parameter(defaultValue = "false")
+    @Parameter(property = "useSnapshotInHotfix", defaultValue = "false")
     protected boolean useSnapshotInHotfix;
     
     /** {@inheritDoc} */

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowHotfixStartMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowHotfixStartMojo.java
@@ -67,7 +67,7 @@ public class GitFlowHotfixStartMojo extends AbstractGitFlowMojo {
      * 
      * @since 1.10.0
      */
-    @Parameter(defaultValue = "false")
+    @Parameter(property = "useSnapshotInHotfix", defaultValue = "false")
     protected boolean useSnapshotInHotfix;
     
     /** {@inheritDoc} */

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowReleaseFinishMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowReleaseFinishMojo.java
@@ -156,7 +156,7 @@ public class GitFlowReleaseFinishMojo extends AbstractGitFlowMojo {
      * 
      * @since 1.10.0
      */
-    @Parameter(defaultValue = "false")
+    @Parameter(property = "useSnapshotInRelease", defaultValue = "false")
     protected boolean useSnapshotInRelease;
     
     /** {@inheritDoc} */

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowReleaseStartMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowReleaseStartMojo.java
@@ -125,7 +125,7 @@ public class GitFlowReleaseStartMojo extends AbstractGitFlowMojo {
      * 
      * @since 1.10.0
      */
-    @Parameter(defaultValue = "false")
+    @Parameter(property = "useSnapshotInRelease", defaultValue = "false")
     protected boolean useSnapshotInRelease;
     
     /** {@inheritDoc} */


### PR DESCRIPTION
I tried to use the new useSnapshotInHotfix in hotfix feature (which is very useful!) from the CLI. 
It did not work however because I guess the absence of "property" makes it unavailable on the CLI.