### PR TITLE
fix merge pom's conflict on release finish using the option useSnapshotInRelease

### DIFF
--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/CommitMessages.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/CommitMessages.java
@@ -17,7 +17,7 @@ package com.amashchenko.maven.plugin.gitflow;
 
 /**
  * Git commit messages.
- * 
+ *
  */
 public class CommitMessages {
     private String featureStartMessage;
@@ -32,6 +32,10 @@ public class CommitMessages {
     private String tagHotfixMessage;
     private String tagReleaseMessage;
 
+    private String updateDevToAvoidConflitsMessage;
+
+    private String updateDevBackPreMergeStateMessage;
+
     public CommitMessages() {
         featureStartMessage = "update versions for feature branch";
         featureFinishMessage = "update versions for development branch";
@@ -44,6 +48,44 @@ public class CommitMessages {
 
         tagHotfixMessage = "tag hotfix";
         tagReleaseMessage = "tag release";
+
+        updateDevToAvoidConflitsMessage = "updating develop poms to master version to avoid merge conflits";
+        updateDevBackPreMergeStateMessage = "updating develop poms version back to pre merge state";
+
+    }
+
+    /**
+     * @return the updateDevToAvoidConflitsMessage
+     */
+    public String getUpdateDevToAvoidConflitsMessage() {
+
+        return updateDevToAvoidConflitsMessage;
+    }
+
+    /**
+     * @param updateDevToAvoidConflitsMessage
+     *            the updateDevToAvoidConflitsMessage to set
+     */
+    public void setUpdateDevToAvoidConflitsMessage(String updateDevToAvoidConflitsMessage) {
+
+        this.updateDevToAvoidConflitsMessage = updateDevToAvoidConflitsMessage;
+    }
+
+    /**
+     * @return the updateDevBackPreMergeStateMessage
+     */
+    public String getUpdateDevBackPreMergeStateMessage() {
+
+        return updateDevBackPreMergeStateMessage;
+    }
+
+    /**
+     * @param updateDevBackPreMergeStateMessage
+     *            the updateDevBackPreMergeStateMessage to set
+     */
+    public void setUpdateDevBackPreMergeStateMessage(String updateDevBackPreMergeStateMessage) {
+
+        this.updateDevBackPreMergeStateMessage = updateDevBackPreMergeStateMessage;
     }
 
     /**


### PR DESCRIPTION
fixes the issue #122 

I hit the same problem. I dig into the code and apply the same solution the old gitflow did. The only way to solve this is to set the version of the release into the develop branch before the merge and later revert this change back. 