### PR TITLE
new property - supportBranchName 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 /target
 
 .DS_Store
-
+.git-credentials
 .idea/
 *.iml
 *.iws

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/CommitMessages.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/CommitMessages.java
@@ -17,7 +17,7 @@ package com.amashchenko.maven.plugin.gitflow;
 
 /**
  * Git commit messages.
- * 
+ *
  */
 public class CommitMessages {
     private String featureStartMessage;
@@ -32,6 +32,8 @@ public class CommitMessages {
     private String tagHotfixMessage;
     private String tagReleaseMessage;
 
+    private String suportStartMessage;
+
     public CommitMessages() {
         featureStartMessage = "update versions for feature branch";
         featureFinishMessage = "update versions for development branch";
@@ -44,6 +46,25 @@ public class CommitMessages {
 
         tagHotfixMessage = "tag hotfix";
         tagReleaseMessage = "tag release";
+
+        suportStartMessage = "update versions for support";
+    }
+
+    /**
+     * @return the suportStartMessage
+     */
+    public String getSuportStartMessage() {
+
+        return suportStartMessage;
+    }
+
+    /**
+     * @param suportStartMessage
+     *            the suportStartMessage to set
+     */
+    public void setSuportStartMessage(String suportStartMessage) {
+
+        this.suportStartMessage = suportStartMessage;
     }
 
     /**

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowSupportStartMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowSupportStartMojo.java
@@ -56,7 +56,7 @@ public class GitFlowSupportStartMojo extends AbstractGitFlowMojo {
      *
      * @since 1.10.1
      */
-    @Parameter(property = "supportBranchName")
+    @Parameter(property = "supportBranchName", defaultValue = "")
     private String supportBranchName;
 
     /**
@@ -65,7 +65,7 @@ public class GitFlowSupportStartMojo extends AbstractGitFlowMojo {
      * @since 1.10.1
      */
     @Parameter(property = "supportVersion", defaultValue = "")
-    private String supportVersion = "";
+    private String supportVersion;
 
     /** {@inheritDoc} */
     @Override

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowSupportStartMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowSupportStartMojo.java
@@ -138,7 +138,7 @@ public class GitFlowSupportStartMojo extends AbstractGitFlowMojo {
                 properties.put("version", projectVersion);
 
                 // git commit -a -m updating versions for new support version
-                gitCommit(commitMessages.getSuportStartMessageMessage(), properties);
+                gitCommit(commitMessages.getSuportStartMessage(), properties);
             }
 
             if (installProject) {


### PR DESCRIPTION
added new property supportBranchName for batch mode so we can customize
the support branch name instead of using the tag by default

added new supportVersion for batch mode to be used when we want to set
the support version to a new version

#125