### PR TITLE
Hotfix improvements

### DIFF
--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowHotfixFinishMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowHotfixFinishMojo.java
@@ -54,6 +54,15 @@ public class GitFlowHotfixFinishMojo extends AbstractGitFlowMojo {
     private boolean skipTestProject = false;
 
     /**
+     * Whether to rebase branch or merge. If <code>true</code> then rebase will
+     * be performed.
+     *
+     * @since 1.10.1
+     */
+    @Parameter(property = "hotfixRebase", defaultValue = "false")
+    private boolean hotfixRebase = false;
+
+    /**
      * Whether to push to the remote.
      * 
      * @since 1.3.0
@@ -99,8 +108,8 @@ public class GitFlowHotfixFinishMojo extends AbstractGitFlowMojo {
      * 
      * @since 1.10.0
      */
-    @Parameter(defaultValue = "false")
-    protected boolean useSnapshotInHotfix;
+    @Parameter(property = "useSnapshotInHotfix", defaultValue = "false")
+    private boolean useSnapshotInHotfix;
     
     /** {@inheritDoc} */
     @Override
@@ -194,7 +203,7 @@ public class GitFlowHotfixFinishMojo extends AbstractGitFlowMojo {
             }
 
             // git merge --no-ff hotfix/...
-            gitMergeNoff(hotfixBranchName);
+            gitMerge(hotfixBranchName, hotfixRebase, true, false);
 
             final String currentVersion = getCurrentProjectVersion();
 

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowHotfixStartMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowHotfixStartMojo.java
@@ -67,7 +67,7 @@ public class GitFlowHotfixStartMojo extends AbstractGitFlowMojo {
      * 
      * @since 1.10.0
      */
-    @Parameter(defaultValue = "false")
+    @Parameter(property = "useSnapshotInHotfix", defaultValue = "false")
     protected boolean useSnapshotInHotfix;
     
     /** {@inheritDoc} */


### PR DESCRIPTION
See individual commits

1. Fix ignore useSnapshotInHotfix parameter - the parameter doesn't work for me without this change.

2. Add hotfixRebase parameter to hotfix-finish task - this copies the releaseRebase parameter, which allows to have linear history without merge commits for support branches with hotfixes.

These two work for me, let me know if you want more to have this merged (docs, tests, more comprehensive solution for the hotfixRebase with no-ff and ff-only parameters..).