### PR TITLE
Fix for incorrect hotfix-finish commit message when using <useSnapshotInHotfix>true</useSnapshotInHotfix>

### DIFF
--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowHotfixFinishMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowHotfixFinishMojo.java
@@ -183,7 +183,7 @@ public class GitFlowHotfixFinishMojo extends AbstractGitFlowMojo {
                 Map<String, String> properties = new HashMap<String, String>();
                 properties.put("version", commitVersion);
 
-                gitCommit(commitMessages.getHotfixStartMessage(), properties);
+                gitCommit(commitMessages.getHotfixFinishMessage(), properties);
             }
 
             if (supportBranchName != null) {


### PR DESCRIPTION
This fixes a problem where the wrong commit message is used when a hotfix is finished. If the hotfix is configured to use `<useSnapshotInHotfix>true</useSnapshotInHotfix>`, then finishing the hotfix would use the 'start' hotfix commit message