### PR TITLE
Fixed typo in <updateDevToAvoidConflitsMessage>

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Since `1.2.1` commit messages can be changed in plugin's configuration section i
             <tagHotfixMessage>Tag hotfix</tagHotfixMessage>
             <tagReleaseMessage>Tag release</tagReleaseMessage>
 
+            <!-- Migration Note: This was called <updateDevToAvoidConflitsMessage> in version 1.11.0, but has been deprecated in favour of the correctly spelt one below. -->
             <updateDevToAvoidConflictsMessage>Update develop to master version to avoid merge conflicts</updateDevToAvoidConflictsMessage>
             <updateDevBackPreMergeStateMessage>Update develop version back to pre-merge state</updateDevBackPreMergeStateMessage>
         </commitMessages>

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Since `1.2.1` commit messages can be changed in plugin's configuration section i
             <tagHotfixMessage>Tag hotfix</tagHotfixMessage>
             <tagReleaseMessage>Tag release</tagReleaseMessage>
 
-            <updateDevToAvoidConflitsMessage>Update develop to master version to avoid merge conflicts</updateDevToAvoidConflitsMessage>
+            <updateDevToAvoidConflictsMessage>Update develop to master version to avoid merge conflicts</updateDevToAvoidConflictsMessage>
             <updateDevBackPreMergeStateMessage>Update develop version back to pre-merge state</updateDevBackPreMergeStateMessage>
         </commitMessages>
     </configuration>

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/CommitMessages.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/CommitMessages.java
@@ -38,7 +38,7 @@ public class CommitMessages {
     private String tagHotfixMessage;
     private String tagReleaseMessage;
 
-    private String updateDevToAvoidConflitsMessage;
+    private String updateDevToAvoidConflictsMessage;
     private String updateDevBackPreMergeStateMessage;
 
     public CommitMessages() {
@@ -60,7 +60,7 @@ public class CommitMessages {
         tagHotfixMessage = "Tag hotfix";
         tagReleaseMessage = "Tag release";
 
-        updateDevToAvoidConflitsMessage = "Update develop to master version to avoid merge conflicts";
+        updateDevToAvoidConflictsMessage = "Update develop to master version to avoid merge conflicts";
         updateDevBackPreMergeStateMessage = "Update develop version back to pre-merge state";
     }
 
@@ -216,18 +216,18 @@ public class CommitMessages {
     }
 
     /**
-     * @return the updateDevToAvoidConflitsMessage
+     * @return the updateDevToAvoidConflictsMessage
      */
-    public String getUpdateDevToAvoidConflitsMessage() {
-        return updateDevToAvoidConflitsMessage;
+    public String getUpdateDevToAvoidConflictsMessage() {
+        return updateDevToAvoidConflictsMessage;
     }
 
     /**
-     * @param updateDevToAvoidConflitsMessage
-     *            the updateDevToAvoidConflitsMessage to set
+     * @param updateDevToAvoidConflictsMessage
+     *            the updateDevToAvoidConflictsMessage to set
      */
-    public void setUpdateDevToAvoidConflitsMessage(String updateDevToAvoidConflitsMessage) {
-        this.updateDevToAvoidConflitsMessage = updateDevToAvoidConflitsMessage;
+    public void setUpdateDevToAvoidConflictsMessage(String updateDevToAvoidConflictsMessage) {
+        this.updateDevToAvoidConflictsMessage = updateDevToAvoidConflictsMessage;
     }
 
     /**

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/CommitMessages.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/CommitMessages.java
@@ -231,6 +231,16 @@ public class CommitMessages {
     }
 
     /**
+     * @param updateDevToAvoidConflitsMessage
+     *            the updateDevToAvoidConflitsMessage to set
+     * @deprecated Use the correctly spelt updateDevToAvoidConflictsMessage instead
+     */
+    @Deprecated
+    public void setUpdateDevToAvoidConflitsMessage(String updateDevToAvoidConflitsMessage) {
+        this.updateDevToAvoidConflictsMessage = updateDevToAvoidConflitsMessage;
+    }
+
+    /**
      * @return the updateDevBackPreMergeStateMessage
      */
     public String getUpdateDevBackPreMergeStateMessage() {

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowReleaseFinishMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowReleaseFinishMojo.java
@@ -274,7 +274,7 @@ public class GitFlowReleaseFinishMojo extends AbstractGitFlowMojo {
                     mvnSetVersions(currentVersion);
 
                     // commit the changes
-                    gitCommit(commitMessages.getUpdateDevToAvoidConflitsMessage());
+                    gitCommit(commitMessages.getUpdateDevToAvoidConflictsMessage());
                 }
 
                 // merge branch master into develop


### PR DESCRIPTION
Corrected spelling of Confli**c**ts but also retained backwards compatibility by allowing the original spelling to coexist. This has been marked as deprecated with the docs updated to reflect that.