### PR TITLE
support to not update/merge develoment-branch on hotfit-finish

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,8 @@ For example, if the release version  is `1.0.2` and `useSnapshotInRelease` is se
 The `gitflow:hotfix-start` and `gitflow:hotfix-finish` goals have `useSnapshotInHotfix` parameter which allows to start the hotfix with SNAPSHOT version and finish it without this value in the version. By default the value is `false`.
 For example, if the hotfix version  is `1.0.2.1` and `useSnapshotInHotfix` is set to `true` and using `gitflow:hotfix-start` goal then the hotfix version will be `1.0.2.1-SNAPSHOT` and when finishing the release with `gitflow:hotfix-finish` goal, the release version will be `1.0.2.1`
 
+The `gitflow:hotfix-finish` goal also supports the parameter `skipUpdateDevBranch` which prevents merging the hotfix-branch into the development-branch and the update of the version of the development-branch. 
+
 Version update of all modules ignoring groupId and artifactId can be forced by setting `versionsForceUpdate` parameter to `true`. The default value is `false`.
 
 ### Remote interaction

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowHotfixFinishMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowHotfixFinishMojo.java
@@ -102,6 +102,9 @@ public class GitFlowHotfixFinishMojo extends AbstractGitFlowMojo {
     @Parameter(property = "useSnapshotInHotfix", defaultValue = "false")
     private boolean useSnapshotInHotfix;
 
+    @Parameter(property = "skipUpdateDevBranch", defaultValue = "false")
+    private boolean skipUpdateDevBranch = false;
+
     /** {@inheritDoc} */
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
@@ -231,7 +234,7 @@ public class GitFlowHotfixFinishMojo extends AbstractGitFlowMojo {
                     gitCheckout(releaseBranch);
                     // git merge --no-ff hotfix/...
                     gitMergeNoff(hotfixBranchName);
-                } else {
+                } else if(!skipUpdateDevBranch) {
                     GitFlowVersionInfo developVersionInfo = new GitFlowVersionInfo(
                             currentVersion);
                     if (notSameProdDevName()) {


### PR DESCRIPTION
In case one don't want to have any changes done to development-branch when finishing a hotfix.