### PR TITLE
bugfix: wrong versions in master when using useSnapshotInHotfix

### DIFF
--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowHotfixFinishMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowHotfixFinishMojo.java
@@ -181,6 +181,16 @@ public class GitFlowHotfixFinishMojo extends AbstractGitFlowMojo {
                 mvnRun(preHotfixGoals);
             }
 
+            if (supportBranchName != null) {
+                gitCheckout(supportBranchName);
+            } else {
+                // git checkout master
+                gitCheckout(gitFlowConfig.getProductionBranch());
+            }
+
+            // git merge --no-ff hotfix/...
+            gitMergeNoff(hotfixBranchName);
+
             String currentHotfixVersion = getCurrentProjectVersion();
             if (useSnapshotInHotfix && ArtifactUtils.isSnapshot(currentHotfixVersion)) {
                 String commitVersion = currentHotfixVersion.replace("-" + Artifact.SNAPSHOT_VERSION, "");
@@ -192,16 +202,6 @@ public class GitFlowHotfixFinishMojo extends AbstractGitFlowMojo {
 
                 gitCommit(commitMessages.getHotfixFinishMessage(), properties);
             }
-
-            if (supportBranchName != null) {
-                gitCheckout(supportBranchName);
-            } else {
-                // git checkout master
-                gitCheckout(gitFlowConfig.getProductionBranch());
-            }
-
-            // git merge --no-ff hotfix/...
-            gitMergeNoff(hotfixBranchName);
 
             final String currentVersion = getCurrentProjectVersion();
 


### PR DESCRIPTION
The versions in the maven poms should be changed _after_ the production branch has been checked out and the hotfix-branch has been merged into it! Otherwise it has no effect, and we end up with SNAPSHOT-versions in production-branch!

That is, because: previously, if skipTestProject is true, no branch has been checked out at this point!