### PR TITLE
New parameter for additionalMergeOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,8 @@ Release branch can be merged with `--ff-only` option by setting `releaseMergeFFO
 
 Feature branch can be squashed before merging by setting `featureSquash` parameter to `true`. The default value is `false` (i.e. merge w/o squash will be performed).
 
+You can also specify the optional parameter `additionalMergeOptions` for goals with merge-operations. It takes an arbitrary string, that will be appended to the merge-command. This is useful when in need for advanced options like `-Xtheirs`.
+
 ### Running custom Maven goals
 
 The `preReleaseGoals` parameter can be used in `gitflow:release-finish` and `gitflow:release` goals to run defined Maven goals before the release.

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
@@ -154,6 +154,9 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
     @Parameter(defaultValue = "${settings}", readonly = true)
     protected Settings settings;
 
+    @Parameter(property = "additionalMergeOptions")
+    protected String additionalMergeOptions;
+
     /**
      * Initializes command line executables.
      * 
@@ -638,16 +641,16 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
         }
         if (rebase) {
             getLog().info("Rebasing '" + branchName + "' branch.");
-            executeGitCommand("rebase", sign, branchName);
+            executeGitCommand("rebase", additionalMergeOptions, sign, branchName);
         } else if (ffonly) {
             getLog().info("Merging (--ff-only) '" + branchName + "' branch.");
-            executeGitCommand("merge", "--ff-only", sign, branchName);
+            executeGitCommand("merge", additionalMergeOptions, "--ff-only", sign, branchName);
         } else if (noff) {
             getLog().info("Merging (--no-ff) '" + branchName + "' branch.");
-            executeGitCommand("merge", "--no-ff", sign, branchName, msgParam, msg);
+            executeGitCommand("merge", additionalMergeOptions, "--no-ff", sign, branchName, msgParam, msg);
         } else {
             getLog().info("Merging '" + branchName + "' branch.");
-            executeGitCommand("merge", sign, branchName, msgParam, msg);
+            executeGitCommand("merge", additionalMergeOptions, sign, branchName, msgParam, msg);
         }
     }
 


### PR DESCRIPTION
The available parameters to control the merge-behavior are quite limited.
Recently we came across the need to specify additional options, in order to make the release-process more robust.

I introduced a new parameter `additionalMergeOptions` in order to be able to specify options like `-Xtheirs` to avoid nasty merge-conflicts. 
E.g. when specifying "-Xtheirs" for "gitflow:release" it will take the changes from staging, when encountering a merge-conflict. And as the versions for the release are updated in the staging-branch beforehand, it is ensured, that you don't end up with snapshot-versions in production-branch.