### PR TITLE
bugfix: wrong versions in master when using useSnapshotInRelease

### DIFF
--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowReleaseFinishMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowReleaseFinishMojo.java
@@ -207,10 +207,10 @@ public class GitFlowReleaseFinishMojo extends AbstractGitFlowMojo {
                 }
             }
 
-            if (!skipTestProject) {
-                // git checkout release/...
-                gitCheckout(releaseBranch);
+            // git checkout release/...
+            gitCheckout(releaseBranch);
 
+            if (!skipTestProject) {
                 // mvn clean test
                 mvnCleanTest();
             }


### PR DESCRIPTION
Same fix as for #155 but for the release-finish goal.