### PR TITLE
bugfix: push release-branch on hotfix-finish if available

### DIFF
--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowHotfixFinishMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowHotfixFinishMojo.java
@@ -306,9 +306,10 @@ public class GitFlowHotfixFinishMojo extends AbstractGitFlowMojo {
                 } else {
                     gitPush(gitFlowConfig.getProductionBranch(), !skipTag);
 
-                    // if no release branch
-                    if (StringUtils.isBlank(releaseBranch)
-                            && notSameProdDevName()) {
+                    if (StringUtils.isNotBlank(releaseBranch)) {
+                        gitPush(releaseBranch, !skipTag);
+                    } else if (StringUtils.isBlank(releaseBranch)
+                            && notSameProdDevName()) { // if no release branch
                         gitPush(gitFlowConfig.getDevelopmentBranch(), !skipTag);
                     }
                 }


### PR DESCRIPTION
ATM, when finishing a hotfix-branch and a release-branch is available, the changes get merged into it but not pushed, even with "pushRemote" enabled.