### PR TITLE
Allow to update a property in addition to version with the generated version on release

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,19 @@ Note that although `${project.version}` can be used, any changes to version intr
 The `argLine` parameter can be used to pass command line arguments to the underlying Maven commands. For example, `-DcreateChecksum` in `mvn gitflow:release-start -DargLine=-DcreateChecksum` 
 will be passed to all underlying Maven commands.
 
+### Update maven properties
+
+Since 1.12.1 version, if you want to update a maven property with the new version, you can set the `propertyUpdate` parameter with the property you want to update.
+For example, `-DpropertyUpdate=revision` will update the `<revision>` property defined in the project `pom.xml` files.
+
+```xml
+<configuration>
+  <!-- since 1.12.1 -->
+  <propertyUpdate>revision</propertyUpdate>
+  ...
+</configuration>
+```
+
 ## Additional goal parameters
 
 The `gitflow:release-finish`, `gitflow:release` and `gitflow:hotfix-finish` goals have `skipTag` parameter. This parameter controls whether the release/hotfix will be tagged in Git.

--- a/src/it/release-it/expected-development-pom.xml
+++ b/src/it/release-it/expected-development-pom.xml
@@ -4,4 +4,7 @@
     <artifactId>gitflow-maven-test</artifactId>
     <packaging>pom</packaging>
     <version>3.0.1-SNAPSHOT</version>
+    <properties>
+        <revision>3.0.1-SNAPSHOT</revision>
+    </properties>
 </project>

--- a/src/it/release-it/expected-production-pom.xml
+++ b/src/it/release-it/expected-production-pom.xml
@@ -4,4 +4,7 @@
     <artifactId>gitflow-maven-test</artifactId>
     <packaging>pom</packaging>
     <version>3.0.0</version>
+    <properties>
+        <revision>3.0.0</revision>
+    </properties>
 </project>

--- a/src/it/release-it/invoker.properties
+++ b/src/it/release-it/invoker.properties
@@ -1,3 +1,3 @@
-invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:release -B -DpushRemote=false -DreleaseVersion=3.0.0
+invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:release -B -DpushRemote=false -DreleaseVersion=3.0.0 -DpropertyUpdate=revision
 
 invoker.description=Non-interactive release with releaseVersion parameter.

--- a/src/it/release-it/pom.xml
+++ b/src/it/release-it/pom.xml
@@ -3,5 +3,8 @@
     <groupId>com.amashchenko.maven.plugin</groupId>
     <artifactId>gitflow-maven-test</artifactId>
     <packaging>pom</packaging>
-    <version>0.0.3-SNAPSHOT</version>
+    <version>${revision}</version>
+    <properties>
+        <revision>0.0.3-SNAPSHOT</revision>
+    </properties>
 </project>

--- a/src/it/release-it/pom.xml
+++ b/src/it/release-it/pom.xml
@@ -3,7 +3,7 @@
     <groupId>com.amashchenko.maven.plugin</groupId>
     <artifactId>gitflow-maven-test</artifactId>
     <packaging>pom</packaging>
-    <version>${revision}</version>
+    <version>0.0.3-SNAPSHOT</version>
     <properties>
         <revision>0.0.3-SNAPSHOT</revision>
     </properties>

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
@@ -46,6 +46,8 @@ import org.codehaus.plexus.util.cli.Commandline;
 public abstract class AbstractGitFlowMojo extends AbstractMojo {
     /** A full name of the versions-maven-plugin set goal. */
     private static final String VERSIONS_MAVEN_PLUGIN_SET_GOAL = "org.codehaus.mojo:versions-maven-plugin:set";
+    /** Update property goal on versions-maven-plugin */
+    private static final String VERSIONS_MAVEN_PLUGIN_SET_PROPERTY_GOAL = "org.codehaus.mojo:versions-maven-plugin:set-property";
     /** Name of the tycho-versions-plugin set-version goal. */
     private static final String TYCHO_VERSIONS_PLUGIN_SET_GOAL = "org.eclipse.tycho:tycho-versions-plugin:set-version";
 
@@ -132,6 +134,14 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
      */
     @Parameter(property = "versionsForceUpdate", defaultValue = "false")
     private boolean versionsForceUpdate = false;
+
+    /**
+     * Property to update when updating versions
+     *
+     * @since 1.12.1
+     */
+    @Parameter(property = "propertyUpdate")
+    private String propertyUpdate = null;
 
     /**
      * The path to the Maven executable. Defaults to "mvn".
@@ -906,19 +916,31 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
             throws MojoFailureException, CommandLineException {
         getLog().info("Updating version(s) to '" + version + "'.");
 
+        String newVersion = "-DnewVersion=" + version;
         String g = "";
         String a = "";
+        String p = "";
+        boolean updateProperty = propertyUpdate != null && !propertyUpdate.isEmpty();
         if (versionsForceUpdate) {
             g = "-DgroupId=";
             a = "-DartifactId=";
         }
 
+        if (updateProperty) {
+            getLog().info("Updating property '" + propertyUpdate + "' to '" + version + "'.");
+            p = "-Dproperties=" + propertyUpdate;
+        }
+
         if (tychoBuild) {
-            executeMvnCommand(TYCHO_VERSIONS_PLUGIN_SET_GOAL, "-DnewVersion="
-                    + version, "-Dtycho.mode=maven");
+            executeMvnCommand(TYCHO_VERSIONS_PLUGIN_SET_GOAL, p, newVersion, "-Dtycho.mode=maven");
         } else {
-            executeMvnCommand(VERSIONS_MAVEN_PLUGIN_SET_GOAL, g, a, "-DnewVersion="
-                    + version, "-DgenerateBackupPoms=false");
+            executeMvnCommand(VERSIONS_MAVEN_PLUGIN_SET_GOAL, g, a, newVersion, "-DgenerateBackupPoms=false");
+
+            // Launch update-property goal if defined
+            if (updateProperty) {
+                executeMvnCommand(VERSIONS_MAVEN_PLUGIN_SET_PROPERTY_GOAL, newVersion,
+                  "-Dproperty=" + propertyUpdate, "-DgenerateBackupPoms=false");
+            }
         }
     }
 


### PR DESCRIPTION
This development allows to define a property to be updated when version tags are changed.

It works with the `versions-maven-plugin` and the `tycho-versions-plugin` as well.

Fix #151 

Regards
Pablo García