### PR TITLE
Allow same property configure to different goal.

### DIFF
--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowFeatureFinishMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowFeatureFinishMojo.java
@@ -35,9 +35,23 @@ import org.codehaus.plexus.util.cli.CommandLineException;
 @Mojo(name = "feature-finish", aggregator = true)
 public class GitFlowFeatureFinishMojo extends AbstractGitFlowMojo {
 
-    /** Whether to keep feature branch after finish. */
+    /**
+     * Whether to keep feature branch after finish.
+     *
+     * @deprecated 1.13.0 Use {@link #keepBranchFeature}
+     */
     @Parameter(property = "keepBranch", defaultValue = "false")
+    @Deprecated
     private boolean keepBranch = false;
+
+
+    /**
+     * Whether to keep feature branch after finish.
+     *
+     * @since 1.13.0
+     */
+    @Parameter(property = "keepBranchFeature", defaultValue = "false")
+    private boolean keepBranchFeature = false;
 
     /**
      * Whether to skip calling Maven test goal before merging the branch.
@@ -60,9 +74,19 @@ public class GitFlowFeatureFinishMojo extends AbstractGitFlowMojo {
      * Whether to push to the remote.
      * 
      * @since 1.3.0
+     * @deprecated 1.13.0 Use {@link #pushRemoteFeatureFinish}
      */
+    @Deprecated
     @Parameter(property = "pushRemote", defaultValue = "true")
     private boolean pushRemote;
+
+    /**
+     * Whether to push to the remote.
+     *
+     * @since 1.13.0
+     */
+    @Parameter(property = "pushRemoteFeatureFinish", defaultValue = "true")
+    private boolean pushRemoteFeatureFinish = true;
 
     /**
      * Feature name to use in non-interactive mode.
@@ -153,15 +177,15 @@ public class GitFlowFeatureFinishMojo extends AbstractGitFlowMojo {
                 mvnCleanInstall();
             }
 
-            if (pushRemote) {
+            if (pushRemoteFeatureFinish) {
                 gitPush(gitFlowConfig.getDevelopmentBranch(), false);
 
-                if (!keepBranch) {
+                if (!keepBranchFeature) {
                     gitPushDelete(featureBranchName);
                 }
             }
 
-            if (!keepBranch) {
+            if (!keepBranchFeature) {
                 if (featureSquash) {
                     // git branch -D feature/...
                     gitBranchDeleteForce(featureBranchName);

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowFeatureStartMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowFeatureStartMojo.java
@@ -56,9 +56,19 @@ public class GitFlowFeatureStartMojo extends AbstractGitFlowMojo {
      * Whether to push to the remote.
      * 
      * @since 1.6.0
+     * @deprecated 1.13.0 Use {@link #pushRemoteFeatureStart}
      */
+    @Deprecated
     @Parameter(property = "pushRemote", defaultValue = "false")
     private boolean pushRemote;
+
+    /**
+     * Whether to push to the remote.
+     *
+     * @since 1.13.0
+     */
+    @Parameter(property = "pushRemoteFeatureStart", defaultValue = "false")
+    private boolean pushRemoteFeatureStart = false;
 
     /**
      * Feature name to use in non-interactive mode.
@@ -153,7 +163,7 @@ public class GitFlowFeatureStartMojo extends AbstractGitFlowMojo {
                 mvnCleanInstall();
             }
 
-            if (pushRemote) {
+            if (pushRemoteFeatureStart) {
                 gitPush(gitFlowConfig.getFeatureBranchPrefix()
                         + featureBranchName, false);
             }

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowHotfixFinishMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowHotfixFinishMojo.java
@@ -41,9 +41,23 @@ public class GitFlowHotfixFinishMojo extends AbstractGitFlowMojo {
     @Parameter(property = "skipTag", defaultValue = "false")
     private boolean skipTag = false;
 
-    /** Whether to keep hotfix branch after finish. */
+    /**
+     * Whether to keep hotfix branch after finish.
+     *
+     * @deprecated 1.13.0 Use {@link #keepBranchHotfix}
+     *
+     */
+    @Deprecated
     @Parameter(property = "keepBranch", defaultValue = "false")
     private boolean keepBranch = false;
+
+    /**
+     * Whether to keep hotfix branch after finish.
+     *
+     * @since 1.13.0
+     */
+    @Parameter(property = "keepBranchHotfix", defaultValue = "false")
+    private boolean keepBranchHotfix = false;
 
     /**
      * Whether to skip calling Maven test goal before merging the branch.
@@ -57,9 +71,19 @@ public class GitFlowHotfixFinishMojo extends AbstractGitFlowMojo {
      * Whether to push to the remote.
      *
      * @since 1.3.0
+     * @deprecated 1.13.0 Use {@link #pushRemoteHotfixFinish}
      */
+    @Deprecated
     @Parameter(property = "pushRemote", defaultValue = "true")
     private boolean pushRemote;
+
+    /**
+     * Whether to push to the remote.
+     *
+     * @since 1.3.0
+     */
+    @Parameter(property = "pushRemoteHotfixFinish", defaultValue = "true")
+    private boolean pushRemoteHotfixFinish = true;
 
     /**
      * Maven goals to execute in the hotfix branch before merging into the
@@ -315,7 +339,7 @@ public class GitFlowHotfixFinishMojo extends AbstractGitFlowMojo {
                 mvnCleanInstall();
             }
 
-            if (pushRemote) {
+            if (pushRemoteHotfixFinish) {
                 if (supportBranchName != null) {
                     gitPush(supportBranchName, !skipTag);
                 } else {
@@ -329,12 +353,12 @@ public class GitFlowHotfixFinishMojo extends AbstractGitFlowMojo {
                     }
                 }
 
-                if (!keepBranch) {
+                if (!keepBranchHotfix) {
                     gitPushDelete(hotfixBranchName);
                 }
             }
 
-            if (!keepBranch) {
+            if (!keepBranchHotfix) {
                 if (skipMergeProdBranch){
                     //force delete as upstream merge is skipped
                     gitBranchDeleteForce(hotfixBranchName);

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowHotfixStartMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowHotfixStartMojo.java
@@ -42,9 +42,19 @@ public class GitFlowHotfixStartMojo extends AbstractGitFlowMojo {
      * Whether to push to the remote.
      * 
      * @since 1.6.0
+     * @deprecated 1.13.0 Use {@link #pushRemoteHotfixStart}
      */
+    @Deprecated
     @Parameter(property = "pushRemote", defaultValue = "false")
     private boolean pushRemote;
+
+    /**
+     * Whether to push to the remote.
+     *
+     * @since 1.13.0
+     */
+    @Parameter(property = "pushRemoteHotfixStart", defaultValue = "false")
+    private boolean pushRemoteHotfixStart = false;
 
     /**
      * Branch to start hotfix in non-interactive mode. Production branch or one of
@@ -246,7 +256,7 @@ public class GitFlowHotfixStartMojo extends AbstractGitFlowMojo {
                 mvnCleanInstall();
             }
 
-            if (pushRemote) {
+            if (pushRemoteHotfixStart) {
                 gitPush(hotfixBranchName, false);
             }
         } catch (CommandLineException e) {

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowReleaseFinishMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowReleaseFinishMojo.java
@@ -37,9 +37,22 @@ public class GitFlowReleaseFinishMojo extends AbstractGitFlowMojo {
     @Parameter(property = "skipTag", defaultValue = "false")
     private boolean skipTag = false;
 
-    /** Whether to keep release branch after finish. */
+    /**
+     * Whether to keep release branch after finish.
+     *
+     * @deprecated 1.13.0 Use {@link #keepBranchRelease}
+     */
     @Parameter(property = "keepBranch", defaultValue = "false")
+    @Deprecated
     private boolean keepBranch = false;
+
+    /**
+     * Whether to keep release branch after finish.
+     *
+     * @since 1.13.0
+     */
+    @Parameter(property = "keepBranchRelease", defaultValue = "false")
+    private boolean keepBranchRelease = false;
 
     /**
      * Whether to skip calling Maven test goal before merging the branch.
@@ -78,9 +91,19 @@ public class GitFlowReleaseFinishMojo extends AbstractGitFlowMojo {
      * Whether to push to the remote.
      *
      * @since 1.3.0
+     * @deprecated 1.13.0 Use {@link #pushRemoteReleaseFinish}
      */
+    @Deprecated
     @Parameter(property = "pushRemote", defaultValue = "true")
     private boolean pushRemote;
+
+    /**
+     * Whether to push to the remote.
+     *
+     * @since 1.13.0
+     */
+    @Parameter(property = "pushRemoteReleaseFinish", defaultValue = "true")
+    private boolean pushRemoteReleaseFinish = true;
 
     /**
      * Whether to use <code>--ff-only</code> option when merging.
@@ -331,18 +354,18 @@ public class GitFlowReleaseFinishMojo extends AbstractGitFlowMojo {
                 mvnCleanInstall();
             }
 
-            if (pushRemote) {
+            if (pushRemoteReleaseFinish) {
                 gitPush(gitFlowConfig.getProductionBranch(), !skipTag);
                 if (notSameProdDevName()) {
                     gitPush(gitFlowConfig.getDevelopmentBranch(), !skipTag);
                 }
 
-                if (!keepBranch) {
+                if (!keepBranchRelease) {
                     gitPushDelete(releaseBranch);
                 }
             }
 
-            if (!keepBranch) {
+            if (!keepBranchRelease) {
                 // git branch -d release/...
                 gitBranchDelete(releaseBranch);
             }

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowReleaseMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowReleaseMojo.java
@@ -76,9 +76,19 @@ public class GitFlowReleaseMojo extends AbstractGitFlowMojo {
      * Whether to push to the remote.
      * 
      * @since 1.3.0
+     * @deprecated 1.13.0 {@link #pushRemoteRelease}
      */
+    @Deprecated
     @Parameter(property = "pushRemote", defaultValue = "true")
     private boolean pushRemote;
+
+    /**
+     * Whether to push to the remote.
+     *
+     * @since 1.13.0
+     */
+    @Parameter(property = "pushRemoteRelease", defaultValue = "true")
+    private boolean pushRemoteRelease = true;
 
     /**
      * Release version to use instead of the default next release version in non
@@ -323,7 +333,7 @@ public class GitFlowReleaseMojo extends AbstractGitFlowMojo {
                 mvnCleanInstall();
             }
 
-            if (pushRemote) {
+            if (pushRemoteRelease) {
                 gitPush(gitFlowConfig.getProductionBranch(), !skipTag);
                 if (notSameProdDevName()) {
                     gitPush(gitFlowConfig.getDevelopmentBranch(), !skipTag);

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowReleaseStartMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowReleaseStartMojo.java
@@ -72,9 +72,19 @@ public class GitFlowReleaseStartMojo extends AbstractGitFlowMojo {
      * Whether to push to the remote.
      *
      * @since 1.6.0
+     * @deprecated 1.13.0 Use {@link #pushRemoteReleaseStart}
      */
     @Parameter(property = "pushRemote", defaultValue = "false")
+    @Deprecated
     private boolean pushRemote;
+
+    /**
+     * Whether to push to the remote.
+     *
+     * @since 1.13.0
+     */
+    @Parameter(property = "pushRemoteReleaseStart", defaultValue = "false")
+    private boolean pushRemoteReleaseStart = false;
 
     /**
      * Whether to commit development version when starting the release (vs when
@@ -232,7 +242,7 @@ public class GitFlowReleaseStartMojo extends AbstractGitFlowMojo {
                 mvnCleanInstall();
             }
 
-            if (pushRemote) {
+            if (pushRemoteReleaseStart) {
                 if (commitDevelopmentVersionAtStart) {
                     gitPush(gitFlowConfig.getDevelopmentBranch(), false);
                 }

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowSupportStartMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowSupportStartMojo.java
@@ -37,9 +37,19 @@ public class GitFlowSupportStartMojo extends AbstractGitFlowMojo {
      * Whether to push to the remote.
      * 
      * @since 1.6.0
+     * @deprecated 1.13.0 Use {@link #pushRemoteSupport}
      */
+    @Deprecated
     @Parameter(property = "pushRemote", defaultValue = "true")
     private boolean pushRemote;
+
+    /**
+     * Whether to push to the remote.
+     *
+     * @since 1.13.0
+     */
+    @Parameter(property = "pushRemoteSupport", defaultValue = "true")
+    private boolean pushRemoteSupport = true;
 
     /**
      * Tag name to use in non-interactive mode.
@@ -108,7 +118,7 @@ public class GitFlowSupportStartMojo extends AbstractGitFlowMojo {
                 mvnCleanInstall();
             }
 
-            if (pushRemote) {
+            if (pushRemoteSupport) {
                 gitPush(gitFlowConfig.getSupportBranchPrefix() + tag, false);
             }
         } catch (CommandLineException e) {


### PR DESCRIPTION
This pull request is a solution for issue [#33](https://github.com/aleksandr-m/gitflow-maven-plugin/issues/33).

Disable 'keepBranch' and 'pushRemote' property, add 'keepBranchXxx' and 'pushRemoteXxx' property to configure to different goal.

e.g.
- For goal `hotfix-start`, `pushRemote` has been marked as `Deprecated`, and add `pushRemoteHotfixStart` property to configuer whether push the hotfix branch to remote.
- For goal `hotfix-finish`, `pushRemote` has been marked as `Deprecated`, and add `pushRemoteHotfixFinish` property to configuer whether push the hotfix branch to remote.
- For goal `hotfix-finish`, `keepBranch` has been marked as `Deprecated`, and add `keepBranchHotfix` property to configuer whether keep branch after finish hotfix.
