### PR TITLE
Add support for running custom maven goals before finishing a feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,9 @@ Feature branch can be squashed before merging by setting `featureSquash` paramet
 
 ### Running custom Maven goals
 
+The `preFeatureFinishGoals` parameter can be used in `gitflow:feature-finish` goal to run defined Maven goals before the finishing and merging a feature.
+E.g. `mvn gitflow:feature-finish -DpreFeatureFinishGoals=test` will run `mvn test` goal in the release branch before merging into the production branch.
+
 The `preReleaseGoals` parameter can be used in `gitflow:release-finish` and `gitflow:release` goals to run defined Maven goals before the release.
 E.g. `mvn gitflow:release-finish -DpreReleaseGoals=test` will run `mvn test` goal in the release branch before merging into the production branch.
 

--- a/README.md
+++ b/README.md
@@ -261,6 +261,9 @@ Feature branch can be squashed before merging by setting `featureSquash` paramet
 The `preFeatureFinishGoals` parameter can be used in `gitflow:feature-finish` goal to run defined Maven goals before the finishing and merging a feature.
 E.g. `mvn gitflow:feature-finish -DpreFeatureFinishGoals=test` will run `mvn test` goal in the release branch before merging into the production branch.
 
+The `postFeatureFinishGoals` parameter can be used in `gitflow:feature-finish` goal to run defined Maven goals after merging a feature.
+E.g. `mvn gitflow:feature-finish -postFeatureFinishGoals=test` will run `mvn test` goal in the release branch after merging into the production branch.
+
 The `preReleaseGoals` parameter can be used in `gitflow:release-finish` and `gitflow:release` goals to run defined Maven goals before the release.
 E.g. `mvn gitflow:release-finish -DpreReleaseGoals=test` will run `mvn test` goal in the release branch before merging into the production branch.
 

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowFeatureFinishMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowFeatureFinishMojo.java
@@ -72,10 +72,20 @@ public class GitFlowFeatureFinishMojo extends AbstractGitFlowMojo {
     @Parameter(property = "featureName")
     private String featureName;
 
+    /**
+     * Maven goals to execute in the feature branch before merging into the
+     * production branch.
+     *
+     * @since 1.13.0
+     */
+    @Parameter(property = "preFeatureFinishGoals")
+    private String preFeatureFinishGoals;
+
+
     /** {@inheritDoc} */
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
-        validateConfiguration();
+        validateConfiguration(preFeatureFinishGoals);
 
         try {
             // check uncommitted changes
@@ -113,6 +123,11 @@ public class GitFlowFeatureFinishMojo extends AbstractGitFlowMojo {
 
                 // mvn clean test
                 mvnCleanTest();
+            }
+
+            // maven goals before merge
+            if (StringUtils.isNotBlank(preFeatureFinishGoals)) {
+                mvnRun(preFeatureFinishGoals);
             }
 
             // git checkout develop
@@ -170,7 +185,7 @@ public class GitFlowFeatureFinishMojo extends AbstractGitFlowMojo {
                     gitBranchDelete(featureBranchName);
                 }
             }
-        } catch (CommandLineException e) {
+        } catch (Exception e) {
             throw new MojoFailureException("feature-finish", e);
         }
     }

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowFeatureFinishMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowFeatureFinishMojo.java
@@ -81,11 +81,19 @@ public class GitFlowFeatureFinishMojo extends AbstractGitFlowMojo {
     @Parameter(property = "preFeatureFinishGoals")
     private String preFeatureFinishGoals;
 
+    /**
+     * Maven goals to execute in the production branch after merging a feature.
+     *
+     * @since 1.13.0
+     */
+    @Parameter(property = "postFeatureFinishGoals")
+    private String postFeatureFinishGoals;
+
 
     /** {@inheritDoc} */
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
-        validateConfiguration(preFeatureFinishGoals);
+        validateConfiguration(preFeatureFinishGoals, postFeatureFinishGoals);
 
         try {
             // check uncommitted changes
@@ -184,6 +192,10 @@ public class GitFlowFeatureFinishMojo extends AbstractGitFlowMojo {
                     // git branch -d feature/...
                     gitBranchDelete(featureBranchName);
                 }
+            }
+            // maven goals after merge
+            if (StringUtils.isNotBlank(postFeatureFinishGoals)) {
+                mvnRun(postFeatureFinishGoals);
             }
         } catch (Exception e) {
             throw new MojoFailureException("feature-finish", e);


### PR DESCRIPTION
Hello!

This PR adds support for running custom maven goals before finishing a feature, similar to the existing `preReleaseGoals` parameter. The new parameter is called `preFeatureFinishGoals` where you can specify goals to be run before merging a feature branch. 

Thanks.