### PR TITLE
bugfix: strip newlines from the end of branch-name when using gitFind…

### DIFF
--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
@@ -444,9 +444,10 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
         String branches;
         if (firstMatch) {
-            branches = executeGitCommandReturn("for-each-ref", "--count=1",
+            branches = org.apache.commons.lang.StringUtils.strip(
+                    executeGitCommandReturn("for-each-ref", "--count=1",
                     "--format=\"%(refname:short)\"", "refs/heads/" + branchName
-                            + wildcard);
+                            + wildcard));
         } else {
             branches = executeGitCommandReturn("for-each-ref",
                     "--format=\"%(refname:short)\"", "refs/heads/" + branchName


### PR DESCRIPTION
…Branches with firstMatch

Prevents bad behavior e.g. in `GitFlowHotfixFinishMojo:251`, where checkout of release-branch would fail.