### PR TITLE
strip single quote (') from beginning and end of argLine value

### DIFF
--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
@@ -1047,7 +1047,8 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
      */
     private void executeMvnCommand(final String... args)
             throws CommandLineException, MojoFailureException {
-        executeCommand(cmdMvn, true, argLine, args);
+        String argLineStripped = argLine.replaceAll("^'|'$", "");
+        executeCommand(cmdMvn, true, argLineStripped, args);
     }
 
     /**

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
@@ -1047,7 +1047,10 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
      */
     private void executeMvnCommand(final String... args)
             throws CommandLineException, MojoFailureException {
-        String argLineStripped = argLine.replaceAll("^'|'$", "");
+        String argLineStripped = null;
+        if (StringUtils.isNotBlank(argLine)) {
+            argLineStripped = argLine.replaceAll("^'|'$", "");
+        }
         executeCommand(cmdMvn, true, argLineStripped, args);
     }
 


### PR DESCRIPTION
Allows multiple arguments in a single-quoted argLine

resolve #190 