### PR TITLE
Allow hotfix-finish to proceed with a free-form named branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 .idea/
 *.iml
 *.iws
+.vscode/settings.json
+.factorypath

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
@@ -462,6 +462,19 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
     }
 
     /**
+     * Executes git branch --show-current to get current branch.
+     *
+     * @return Git current branch.
+     * @throws MojoFailureException
+     * @throws CommandLineException
+     */
+    protected String gitGetCurrentBranch() throws MojoFailureException, CommandLineException {
+        String currentBranch = executeGitCommandReturn("branch", "--show-current");
+        currentBranch = removeQuotes(currentBranch);
+        return currentBranch;
+    }
+
+    /**
      * Executes git for-each-ref to get all tags.
      *
      * @return Git tags.

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowHotfixFinishMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowHotfixFinishMojo.java
@@ -130,6 +130,9 @@ public class GitFlowHotfixFinishMojo extends AbstractGitFlowMojo {
             String hotfixBranchName = null;
             if (settings.isInteractiveMode()) {
                 hotfixBranchName = promptBranchName();
+            } else if (gitGetCurrentBranch().startsWith(gitFlowConfig.getHotfixBranchPrefix())) {
+                // If we're already on a hotfix branch, assume it's the branch we wish to use.
+                hotfixBranchName = gitGetCurrentBranch();
             } else if (StringUtils.isNotBlank(hotfixVersion)) {
                 final String branch = gitFlowConfig.getHotfixBranchPrefix()
                         + hotfixVersion;


### PR DESCRIPTION
This change detects if we are currently on a hotfix branch, and then proceeds with releasing the hotfix even if what follows after the prefix is not a version number.