### PR TITLE
property value as version in pom not resolved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v1.12.2 (forked)
+* allows property value in version of pom.xml. This is often used in CI-friendly versioning.
+
 ## v1.12.0
 
 * Fixed wrong versions in production branch when using `useSnapshotInHotfix` parameter

--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ will be passed to all underlying Maven commands.
 Since 1.12.1 version, if you want to update a maven property with the new version, you can set the `versionProperty` parameter with the property you want to update.
 For example, `-DversionProperty=revision` will update the `<revision>` property defined in the project pom.xml.
 
+Since 1.12.2 version, the `<version>` of your pom.xml will be evaluated so that version value such as `<version>${revision}</version>` will correctly recognized (if property "revision" can be resolved, of course). Notice that if you need gitflow-maven-plugin not modify version tag after release, you must use parameter `skipUpdateVersion=true`
+
 ## Additional goal parameters
 
 The `gitflow:release-finish`, `gitflow:release` and `gitflow:hotfix-finish` goals have `skipTag` parameter. This parameter controls whether the release/hotfix will be tagged in Git.

--- a/pom.xml
+++ b/pom.xml
@@ -17,11 +17,11 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.amashchenko.maven.plugin</groupId>
+    <groupId>com.openmindlab.maven.plugin</groupId>
     <artifactId>gitflow-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
     <name>gitflow-maven-plugin</name>
-    <version>1.12.1-SNAPSHOT</version>
+    <version>1.12.2-SNAPSHOT</version>
 
     <description>The Git-Flow Maven Plugin supports various Git workflows, including Vincent Driessen's successful Git branching model and GitHub Flow. This plugin runs Git and Maven commands from the command line. Supports Eclipse Plugins build with Tycho.</description>
 
@@ -38,6 +38,9 @@
     <developers>
         <developer>
             <name>Aleksandr Mashchenko</name>
+        </developer>
+         <developer>
+            <name>Vincenzo Cerbone</name>
         </developer>
     </developers>
 
@@ -65,8 +68,8 @@
     <properties>
         <java.version>1.6</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <scm.url>scm:git:git@github.com:aleksandr-m/gitflow-maven-plugin.git</scm.url>
-        <url>https://github.com/aleksandr-m/gitflow-maven-plugin</url>
+        <scm.url>scm:git:git@github.com:openmindlab/gitflow-maven-plugin.git</scm.url>
+        <url>https://github.com/openmindlab/gitflow-maven-plugin</url>
         <maven-plugin-plugin.version>3.6.0</maven-plugin-plugin.version>
     </properties>
 

--- a/src/it/feature-start-3-it/expected-pom.xml
+++ b/src/it/feature-start-3-it/expected-pom.xml
@@ -1,0 +1,10 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.amashchenko.maven.plugin</groupId>
+    <artifactId>gitflow-maven-test</artifactId>
+    <packaging>pom</packaging>
+    <version>${revision}</version>
+    <properties>
+      <revision>0.0.4-test-SNAPSHOT</revision>
+    </properties>
+</project>

--- a/src/it/feature-start-3-it/gitignorefile
+++ b/src/it/feature-start-3-it/gitignorefile
@@ -1,0 +1,5 @@
+build.log
+expected-pom.xml
+invoker.properties
+init.bsh
+verify.bsh

--- a/src/it/feature-start-3-it/init.bsh
+++ b/src/it/feature-start-3-it/init.bsh
@@ -1,0 +1,20 @@
+try {
+    new File(basedir, "gitignorefile").renameTo(new File(basedir, ".gitignore"));
+
+    Process p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " init");
+    p.waitFor();
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " add .");
+    p.waitFor();
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " commit -m init");
+    p.waitFor();
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " checkout -b develop");
+    p.waitFor();
+
+} catch (Exception e) {
+    e.printStackTrace();
+    return false;
+}
+return true;

--- a/src/it/feature-start-3-it/invoker.properties
+++ b/src/it/feature-start-3-it/invoker.properties
@@ -1,0 +1,3 @@
+invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:feature-start -B -DfeatureName=test -DskipUpdateVersion=true -DversionProperty=revision
+
+invoker.description=Non-interactive feature-start.

--- a/src/it/feature-start-3-it/pom.xml
+++ b/src/it/feature-start-3-it/pom.xml
@@ -1,0 +1,10 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.amashchenko.maven.plugin</groupId>
+    <artifactId>gitflow-maven-test</artifactId>
+    <packaging>pom</packaging>
+    <version>${revision}</version>
+    <properties>
+      <revision>0.0.4-SNAPSHOT</revision>
+    </properties>
+</project>

--- a/src/it/feature-start-3-it/verify.bsh
+++ b/src/it/feature-start-3-it/verify.bsh
@@ -1,0 +1,27 @@
+import org.codehaus.plexus.util.FileUtils;
+
+try {
+    File gitRef = new File(basedir, ".git/refs/heads/feature/test");
+    if (!gitRef.exists()) {
+        System.out.println("feature-start .git/refs/heads/feature/test doesn't exist");
+        return false;
+    }
+
+    File file = new File(basedir, "pom.xml");
+    File expectedFile = new File(basedir, "expected-pom.xml");
+
+    String actual = FileUtils.fileRead(file, "UTF-8");
+    String expected = FileUtils.fileRead(expectedFile, "UTF-8");
+
+    actual = actual.replaceAll("\\r?\\n", "");
+    expected = expected.replaceAll("\\r?\\n", "");
+
+    if (!expected.equals(actual)) {
+        System.out.println("feature-start expected: " + expected + " actual was:" + actual);
+        return false;
+    }
+} catch (Exception e) {
+    e.printStackTrace();
+    return false;
+}
+return true;

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -10,10 +10,10 @@
 
 # Usage
 
-  If you feel like the plugin is missing a feature or has a defect, create a [new issue](https://github.com/aleksandr-m/gitflow-maven-plugin/issues/new) or submit a [Pull Request](https://github.com/aleksandr-m/gitflow-maven-plugin/pulls).
+  If you feel like the plugin is missing a feature or has a defect, create a [new issue](https://github.com/openmindlab/gitflow-maven-plugin/issues/new) or submit a [Pull Request](https://github.com/aleksandr-m/gitflow-maven-plugin/pulls).
   When creating a new issue, please provide a comprehensive description of your
   concern. Especially for fixing bugs it is crucial that the developers can reproduce your problem. For this reason,
   entire debug logs, POMs or most preferably little demo projects attached to the issue are very much appreciated.
   Of course, patches are welcome, too. Contributors can check out the project from our
-  [source repository](https://github.com/aleksandr-m/gitflow-maven-plugin) and will find supplementary information in the
+  [source repository](https://github.com/openmindlab/gitflow-maven-plugin) and will find supplementary information in the
   [guide to helping with Maven](http://maven.apache.org/guides/development/guide-helping.html).

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -5,7 +5,7 @@
         <name>Git-Flow Maven Plugin</name>
     </bannerLeft>
 
-    <googleAnalyticsAccountId>UA-65158625-2</googleAnalyticsAccountId>
+    <googleAnalyticsAccountId></googleAnalyticsAccountId>
 
     <publishDate position="right"/>
     <version position="right"/>
@@ -21,7 +21,7 @@
            <leftColumnClass>span3</leftColumnClass>
            <bodyColumnClass>span9</bodyColumnClass>
            <gitHub>
-               <projectId>aleksandr-m/gitflow-maven-plugin</projectId>
+               <projectId>openmindlab/gitflow-maven-plugin</projectId>
                <ribbonOrientation>right</ribbonOrientation>
                <ribbonColor>red</ribbonColor>
             </gitHub>


### PR DESCRIPTION
resolved the problem of having a property value in current project <version> tag. This is a common setup for CI-friendly maven versioning. See feature-start-3-it test case.