### PR TITLE
Update to Java 8 and Junit 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     </distributionManagement>
 
     <properties>
-        <java.version>1.6</java.version>
+        <java.version>1.8</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <scm.url>scm:git:git@github.com:aleksandr-m/gitflow-maven-plugin.git</scm.url>
         <url>https://github.com/aleksandr-m/gitflow-maven-plugin</url>
@@ -103,8 +103,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
+                    <source>8</source>
+                    <target>8</target>
                     <encoding>${project.build.sourceEncoding}</encoding>
                 </configuration>
             </plugin>
@@ -257,9 +257,9 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.5.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/java/com/amashchenko/maven/plugin/gitflow/FeatureVersionTest.java
+++ b/src/test/java/com/amashchenko/maven/plugin/gitflow/FeatureVersionTest.java
@@ -15,42 +15,31 @@
  */
 package com.amashchenko.maven.plugin.gitflow;
 
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
 import java.util.Arrays;
 import java.util.Collection;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
-@RunWith(Parameterized.class)
 public class FeatureVersionTest {
-    private final String version;
-    private final String featureName;
-    private final String expectedVersion;
 
-    public FeatureVersionTest(final String version, final String featureName,
-            final String expectedVersion) {
-        this.version = version;
-        this.featureName = featureName;
-        this.expectedVersion = expectedVersion;
+    public static Collection<Arguments> data() {
+        return Arrays.asList(
+                arguments("0.9-SNAPSHOT", "feature", "0.9-feature-SNAPSHOT"),
+                arguments("0.9-RC3-SNAPSHOT", "feature", "0.9-RC3-feature-SNAPSHOT"),
+                arguments("0.9", "feature", "0.9-feature"),
+                arguments("0.9-RC3", "feature", "0.9-RC3-feature"),
+                arguments("0.9-RC3", null, "0.9-RC3"));
     }
 
-    @Parameters
-    public static Collection<Object[]> data() {
-        return Arrays.asList(new Object[][] {
-                        { "0.9-SNAPSHOT", "feature", "0.9-feature-SNAPSHOT" },
-                        { "0.9-RC3-SNAPSHOT", "feature",
-                                        "0.9-RC3-feature-SNAPSHOT" },
-                        { "0.9", "feature", "0.9-feature" },
-                        { "0.9-RC3", "feature", "0.9-RC3-feature" },
-                        { "0.9-RC3", null, "0.9-RC3" } });
-    }
-
-    @Test
-    public void testFeatureVersion() throws Exception {
-        Assert.assertEquals(expectedVersion,
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testFeatureVersion(String version, String featureName, String expectedVersion) throws Exception {
+        Assertions.assertEquals(expectedVersion,
                 new GitFlowVersionInfo(version).featureVersion(featureName));
     }
 }

--- a/src/test/java/com/amashchenko/maven/plugin/gitflow/GitFlowVersionInfoTest.java
+++ b/src/test/java/com/amashchenko/maven/plugin/gitflow/GitFlowVersionInfoTest.java
@@ -16,81 +16,83 @@
 package com.amashchenko.maven.plugin.gitflow;
 
 import org.apache.maven.shared.release.versions.VersionParseException;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class GitFlowVersionInfoTest {
+
     @Test
     public void testCreating() throws Exception {
         final String version = "0.9";
         GitFlowVersionInfo info = new GitFlowVersionInfo(version);
-        Assert.assertNotNull(info);
-        Assert.assertEquals(version, info.toString());
+        assertNotNull(info);
+        assertEquals(version, info.toString());
     }
 
-    @Test(expected = VersionParseException.class)
+    @Test
     public void testVersionParseException() throws Exception {
-        new GitFlowVersionInfo("");
+        assertThrows(VersionParseException.class, () -> new GitFlowVersionInfo(""));
     }
 
     @Test
     public void testIsValidVersion() throws Exception {
-        Assert.assertTrue(GitFlowVersionInfo.isValidVersion("0.9"));
-        Assert.assertTrue(GitFlowVersionInfo.isValidVersion("some-SNAPSHOT"));
-        Assert.assertTrue(GitFlowVersionInfo
+        assertTrue(GitFlowVersionInfo.isValidVersion("0.9"));
+        assertTrue(GitFlowVersionInfo.isValidVersion("some-SNAPSHOT"));
+        assertTrue(GitFlowVersionInfo
                 .isValidVersion("0.9-RC3-feature-SNAPSHOT"));
 
-        Assert.assertFalse(GitFlowVersionInfo.isValidVersion("some.0.9"));
-        Assert.assertFalse(GitFlowVersionInfo.isValidVersion(null));
-        Assert.assertFalse(GitFlowVersionInfo.isValidVersion(""));
-        Assert.assertFalse(GitFlowVersionInfo.isValidVersion(" "));
-        Assert.assertFalse(GitFlowVersionInfo.isValidVersion("-1"));
+        assertFalse(GitFlowVersionInfo.isValidVersion("some.0.9"));
+        assertFalse(GitFlowVersionInfo.isValidVersion(null));
+        assertFalse(GitFlowVersionInfo.isValidVersion(""));
+        assertFalse(GitFlowVersionInfo.isValidVersion(" "));
+        assertFalse(GitFlowVersionInfo.isValidVersion("-1"));
     }
 
     @Test
     public void testHotfixVersion() throws Exception {
         GitFlowVersionInfo info = new GitFlowVersionInfo("0.9");
-        Assert.assertNotNull(info);
-        Assert.assertEquals("0.10", info.hotfixVersion(false));
+        assertNotNull(info);
+        assertEquals("0.10", info.hotfixVersion(false));
     }
 
     @Test
     public void testHotfixVersion2() throws Exception {
         GitFlowVersionInfo info = new GitFlowVersionInfo("0.9-SNAPSHOT");
-        Assert.assertNotNull(info);
-        Assert.assertEquals("0.10", info.hotfixVersion(false));
+        assertNotNull(info);
+        assertEquals("0.10", info.hotfixVersion(false));
     }
 
     @Test
     public void testHotfixVersion3() throws Exception {
         GitFlowVersionInfo info = new GitFlowVersionInfo("0.9");
-        Assert.assertNotNull(info);
-        Assert.assertEquals("0.10", info.hotfixVersion(true));
+        assertNotNull(info);
+        assertEquals("0.10", info.hotfixVersion(true));
     }
 
     @Test
     public void testHotfixVersion4() throws Exception {
         GitFlowVersionInfo info = new GitFlowVersionInfo("0.9-SNAPSHOT");
-        Assert.assertNotNull(info);
-        Assert.assertEquals("0.10-SNAPSHOT", info.hotfixVersion(true));
+        assertNotNull(info);
+        assertEquals("0.10-SNAPSHOT", info.hotfixVersion(true));
     }
 
     @Test
     public void testDigitsVersionInfo() throws Exception {
         GitFlowVersionInfo info = new GitFlowVersionInfo("0.9");
-        Assert.assertNotNull(info);
+        assertNotNull(info);
         info = info.digitsVersionInfo();
-        Assert.assertNotNull(info);
-        Assert.assertEquals(new GitFlowVersionInfo("0.9"), info);
+        assertNotNull(info);
+        assertEquals(new GitFlowVersionInfo("0.9"), info);
     }
 
     @Test
     public void testDigitsVersionInfo2() throws Exception {
         GitFlowVersionInfo info = new GitFlowVersionInfo(
                 "0.9-RC3-feature-SNAPSHOT");
-        Assert.assertNotNull(info);
+        assertNotNull(info);
         info = info.digitsVersionInfo();
-        Assert.assertNotNull(info);
-        Assert.assertEquals(new GitFlowVersionInfo("0.9"), info);
+        assertNotNull(info);
+        assertEquals(new GitFlowVersionInfo("0.9"), info);
     }
 }

--- a/src/test/java/com/amashchenko/maven/plugin/gitflow/NextSnapshotVersionTest.java
+++ b/src/test/java/com/amashchenko/maven/plugin/gitflow/NextSnapshotVersionTest.java
@@ -15,58 +15,45 @@
  */
 package com.amashchenko.maven.plugin.gitflow;
 
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
 import java.util.Arrays;
 import java.util.Collection;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
-@RunWith(Parameterized.class)
 public class NextSnapshotVersionTest {
-    private final String version;
-    private final Integer index;
-    private final String expectedVersion;
 
-    public NextSnapshotVersionTest(final String version, final Integer index,
-            final String expectedVersion) {
-        this.version = version;
-        this.index = index;
-        this.expectedVersion = expectedVersion;
+    public static Collection<Arguments> data() {
+        return Arrays.asList(
+                arguments("some-SNAPSHOT", null, "some-SNAPSHOT"),
+                arguments("some-SNAPSHOT", 0, "some-SNAPSHOT"),
+                arguments("0.58", null, "0.59-SNAPSHOT"),
+                arguments("0.58", -1, "0.59-SNAPSHOT"),
+                arguments("0.58", 0, "1.0-SNAPSHOT"),
+                arguments("0.58", 1, "0.59-SNAPSHOT"),
+                arguments("0.58", 100, "0.59-SNAPSHOT"),
+                arguments("0.9", 1, "0.10-SNAPSHOT"),
+                arguments("0.09", 1, "0.10-SNAPSHOT"),
+                arguments("0.0009", 0, "1.0-SNAPSHOT"),
+                arguments("0.0009", 1, "0.0010-SNAPSHOT"),
+                arguments("0.09-RC2", null, "0.09-RC3-SNAPSHOT"),
+                arguments("0.09-RC3", 0, "1.0-RC3-SNAPSHOT"),
+                arguments("0.09-RC3-SNAPSHOT", 0, "1.0-RC3-SNAPSHOT"),
+                arguments("0.9-SNAPSHOT", null, "0.10-SNAPSHOT"),
+                arguments("0.09-RC3-feature-SNAPSHOT", 0, "1.0-RC3-feature-SNAPSHOT"),
+                arguments("0.09-RC3-feature", null, "0.09-RC4-feature-SNAPSHOT"),
+                arguments("2.3.4", 0, "3.0.0-SNAPSHOT"),
+                arguments("2.3.4", 1, "2.4.0-SNAPSHOT"));
     }
 
-    @Parameters
-    public static Collection<Object[]> data() {
-        return Arrays
-                .asList(new Object[][] {
-                                { "some-SNAPSHOT", null, "some-SNAPSHOT" },
-                                { "some-SNAPSHOT", 0, "some-SNAPSHOT" },
-                                { "0.58", null, "0.59-SNAPSHOT" },
-                                { "0.58", -1, "0.59-SNAPSHOT" },
-                                { "0.58", 0, "1.0-SNAPSHOT" },
-                                { "0.58", 1, "0.59-SNAPSHOT" },
-                                { "0.58", 100, "0.59-SNAPSHOT" },
-                                { "0.9", 1, "0.10-SNAPSHOT" },
-                                { "0.09", 1, "0.10-SNAPSHOT" },
-                                { "0.0009", 0, "1.0-SNAPSHOT" },
-                                { "0.0009", 1, "0.0010-SNAPSHOT" },
-                                { "0.09-RC2", null, "0.09-RC3-SNAPSHOT" },
-                                { "0.09-RC3", 0, "1.0-RC3-SNAPSHOT" },
-                                { "0.09-RC3-SNAPSHOT", 0, "1.0-RC3-SNAPSHOT" },
-                                { "0.9-SNAPSHOT", null, "0.10-SNAPSHOT" },
-                                { "0.09-RC3-feature-SNAPSHOT", 0,
-                                                "1.0-RC3-feature-SNAPSHOT" },
-                                { "0.09-RC3-feature", null,
-                                                "0.09-RC4-feature-SNAPSHOT" },
-                                { "2.3.4", 0, "3.0.0-SNAPSHOT" },
-                                { "2.3.4", 1, "2.4.0-SNAPSHOT" } });
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testNextSnapshotVersion(String version, Integer index, String expectedVersion) throws Exception {
+        assertEquals(expectedVersion, new GitFlowVersionInfo(version).nextSnapshotVersion(index));
     }
 
-    @Test
-    public void testNextSnapshotVersion() throws Exception {
-        Assert.assertEquals(expectedVersion,
-                new GitFlowVersionInfo(version).nextSnapshotVersion(index));
-    }
 }

--- a/src/test/java/com/amashchenko/maven/plugin/gitflow/ValidateConfigurationTest.java
+++ b/src/test/java/com/amashchenko/maven/plugin/gitflow/ValidateConfigurationTest.java
@@ -15,39 +15,35 @@
  */
 package com.amashchenko.maven.plugin.gitflow;
 
+import org.apache.maven.plugin.MojoFailureException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
 import java.util.Arrays;
 import java.util.Collection;
 
-import org.apache.maven.plugin.MojoFailureException;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
-@RunWith(Parameterized.class)
 public class ValidateConfigurationTest {
-    private final String argLine;
-    private final boolean expected;
 
-    public ValidateConfigurationTest(String argLine, boolean expected) {
-        this.argLine = argLine;
-        this.expected = expected;
+    public static Collection<Arguments> data() {
+        return Arrays.asList(
+                arguments("-X -e", true),
+                arguments("-DsomeArg1=true", true),
+                arguments(null, true),
+                arguments("", true),
+                arguments("-DsomeArg & clean", false),
+                arguments("-DsomeArg  && clean", false),
+                arguments("-DsomeArg  | clean", false),
+                arguments("-DsomeArg  || clean", false),
+                arguments("-DsomeArg  ; clean", false));
     }
 
-    @Parameters(name = "{0}->{1}")
-    public static Collection<Object[]> data() {
-        return Arrays.asList(new Object[][] { { "-X -e", true },
-                        { "-DsomeArg1=true", true }, { null, true },
-                        { "", true }, { "-DsomeArg & clean", false },
-                        { "-DsomeArg  && clean", false },
-                        { "-DsomeArg  | clean", false },
-                        { "-DsomeArg  || clean", false },
-                        { "-DsomeArg  ; clean", false } });
-    }
-
-    @Test
-    public void testValidateConfiguration() throws Exception {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testValidateConfiguration(String argLine, boolean expected) throws Exception {
         GitFlowReleaseStartMojo mojo = new GitFlowReleaseStartMojo();
         mojo.setArgLine(argLine);
 
@@ -55,7 +51,7 @@ public class ValidateConfigurationTest {
             mojo.validateConfiguration();
         } catch (MojoFailureException e) {
             if (expected) {
-                Assert.fail();
+                Assertions.fail();
             }
         }
     }


### PR DESCRIPTION
@aleksandr-m I thought I'd update the tests to Junit 5 as it provides a nicer syntax for parameterized tests which are used a lot in the project.
I only realized later that Junit 5 requires Java 8 so I updated the Java version as well - I hope that is ok?