### PR TITLE
Add releases dates in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v1.13.0
+## v1.13.0 (2019-09-09)
 
 * Added ability to change git merge messages for feature and hotfix goals - [#185](https://github.com/aleksandr-m/gitflow-maven-plugin/issues/185)
 * Added support for running custom Maven goals in `feature-finish` - [#177](https://github.com/aleksandr-m/gitflow-maven-plugin/pull/177)
@@ -8,7 +8,7 @@
 * Added ability to skip updating `version`
 * Added support for updating property in pom (e.g. `revision`) - [#151](https://github.com/aleksandr-m/gitflow-maven-plugin/issues/151)
 
-## v1.12.0
+## v1.12.0 (2019-04-09)
 
 * Fixed wrong versions in production branch when using `useSnapshotInHotfix` parameter
 * Fixed wrong versions in production branch when using `useSnapshotInRelease` parameter - [#158](https://github.com/aleksandr-m/gitflow-maven-plugin/pull/158)
@@ -20,7 +20,7 @@
 * Added support to skip merging into the production branch in `hotfix-finish` goal - [#164](https://github.com/aleksandr-m/gitflow-maven-plugin/pull/164)
 * Improved usage and content of commit messages
 
-## v1.11.0
+## v1.11.0 (2018-12-11)
 
 * Fixed `versionsForceUpdate` parameter doesn't work on windows - [#134](https://github.com/aleksandr-m/gitflow-maven-plugin/issues/134)
 * Fixed merge pom's conflict on release finish using `useSnapshotInRelease` - [#123](https://github.com/aleksandr-m/gitflow-maven-plugin/pull/123)
@@ -31,7 +31,7 @@
 * Added configurable commit message for release start with `commitDevelopmentVersionAtStart` - [#120](https://github.com/aleksandr-m/gitflow-maven-plugin/issues/120)
 * Added ability to use `useSnapshotInHotfix` and `useSnapshotInRelease` from the command line with a warning message in logs
 
-## v1.10.0
+## v1.10.0 (2018-08-02)
 
 * Improved branch removing. Deleting remote first then local branch to avoid failing a build - [#114](https://github.com/aleksandr-m/gitflow-maven-plugin/issues/114)
 * Added ability to use different versions-maven-plugin version - [#116](https://github.com/aleksandr-m/gitflow-maven-plugin/issues/116)
@@ -40,7 +40,7 @@
 * Added ability to use SNAPSHOT versions in release - [#98](https://github.com/aleksandr-m/gitflow-maven-plugin/issues/98)
 * Added ability to use SNAPSHOT versions in hotfix - [#81](https://github.com/aleksandr-m/gitflow-maven-plugin/issues/81)
 
-## v1.9.0
+## v1.9.0 (2018-01-27)
 
 * Fixed not failing the whole build on goals errors
 * Added ability to make a GPG-signed tags and commits - [#73](https://github.com/aleksandr-m/gitflow-maven-plugin/issues/73)
@@ -50,12 +50,12 @@
 * Added ability to fetch and checkout from the remote if local branch doesn't exist in `hotfix-finish` goal - [#87](https://github.com/aleksandr-m/gitflow-maven-plugin/pull/87)
 * Improved finding of hotfix support branches in `hotfix-finish` goal - [#68](https://github.com/aleksandr-m/gitflow-maven-plugin/issues/68)
 
-## v1.8.0
+## v1.8.0 (2017-11-04)
 
 * Added ability to run custom Maven goals before and after release and hotfix - [#13](https://github.com/aleksandr-m/gitflow-maven-plugin/issues/13), [#29](https://github.com/aleksandr-m/gitflow-maven-plugin/issues/29), [#54](https://github.com/aleksandr-m/gitflow-maven-plugin/issues/54)
 * Added ability to allow to pass arguments to the underlying Maven commands - [#53](https://github.com/aleksandr-m/gitflow-maven-plugin/issues/53)
 
-## v1.7.0
+## v1.7.0 (2017-08-30)
 
 * Fixed [#19](https://github.com/aleksandr-m/gitflow-maven-plugin/issues/19) - Avoid merge conflict in `hotfix-finish`
 * Fixed [#60](https://github.com/aleksandr-m/gitflow-maven-plugin/pull/60) - The `releaseMergeFFOnly` is used when merging release to develop
@@ -64,7 +64,7 @@
 * Added ability to replace `@{featureName}` in commit messages - [#62](https://github.com/aleksandr-m/gitflow-maven-plugin/issues/62)
 * Added ability to replace `@{version}` with updated version in commit messages - [#41](https://github.com/aleksandr-m/gitflow-maven-plugin/issues/41)
 
-## v1.6.0
+## v1.6.0 (2017-07-03)
 
 * Fixed [#47](https://github.com/aleksandr-m/gitflow-maven-plugin/issues/47) - Wrong development version after `release` goal
 * Added option to push to the remote in start goals - [#32](https://github.com/aleksandr-m/gitflow-maven-plugin/issues/32)
@@ -75,7 +75,7 @@
 * Added upstream (tracking) reference for the branch when pushing to remote - [#52](https://github.com/aleksandr-m/gitflow-maven-plugin/issues/52)
 * Various improvements
 
-## v1.5.0
+## v1.5.0 (2017-04-12)
 
 * Added ability to fetch and checkout from the remote if local branch doesn't exist - closes [#40](https://github.com/aleksandr-m/gitflow-maven-plugin/issues/40)
 * Added support for the `support` branches - see [#23](https://github.com/aleksandr-m/gitflow-maven-plugin/issues/23)
@@ -84,94 +84,94 @@
 * Improved getting project versions
 * Other small fixes and code improvements
 
-## v1.4.1
+## v1.4.1 (2017-03-05)
 
 * Fixed [#39](https://github.com/aleksandr-m/gitflow-maven-plugin/issues/39) - Snapshot dependency check should not check internal dependencies of a multi module project
 * Improved error reporting of snapshot dependency check
 
-## v1.4.0
+## v1.4.0 (2017-02-12)
 
 * Added support for `--ff-only` option for release merge ([#30](https://github.com/aleksandr-m/gitflow-maven-plugin/issues/30))
 * Added validation for branch names
 * Fixed [#28](https://github.com/aleksandr-m/gitflow-maven-plugin/issues/28) - Release-start and release-finish doesn't check for SNAPSHOT dependencies on submodules
 
-## v1.3.1
+## v1.3.1 (2016-11-04)
 
 * Added ability to set version in non interactive mode (see [#25](https://github.com/aleksandr-m/gitflow-maven-plugin/pull/25))
 * Don't merge/tag/fetch/push to the same branch when using single branch model like GitHub Flow (see [#22](https://github.com/aleksandr-m/gitflow-maven-plugin/issues/22))
 
-## v1.3.0
+## v1.3.0 (2016-09-30)
 
 * Remote interaction. Added `fetchRemote` and `pushRemote` parameters.
 * Updated default executable names (see [#20](https://github.com/aleksandr-m/gitflow-maven-plugin/issues/20))
 
-## v1.2.3
+## v1.2.3 (2016-06-19)
 
 * Added `featureSquash` parameter which allows to squash feature commits (see [#17](https://github.com/aleksandr-m/gitflow-maven-plugin/issues/17))
 * Added ability to rebase or merge w/o no-ff option in release goals (see [#14](https://github.com/aleksandr-m/gitflow-maven-plugin/issues/14))
 * Fixed [#18](https://github.com/aleksandr-m/gitflow-maven-plugin/issues/18) - Executing commands with verbose parameter
 
-## v1.2.2
+## v1.2.2 (2016-03-24)
 
 * Added `allowSnapshots` parameter to allow SNAPSHOT dependencies on releasing (see [#10](https://github.com/aleksandr-m/gitflow-maven-plugin/issues/10))
 * Dependencies versions updated
 
-## v1.2.1
+## v1.2.1 (2015-12-22)
 
 * Added `commitMessages` configuration which allows to customize commit messages (see [#8](https://github.com/aleksandr-m/gitflow-maven-plugin/issues/8))
 * Added maven site
 
-## v1.2.0
+## v1.2.0 (2015-11-01)
 
 * Added `release` goal for creating releases w/o separate release branch
 * Added `sameBranchName` parameter which allows to use the same name for the release branch (see [#5](https://github.com/aleksandr-m/gitflow-maven-plugin/issues/5))
 * Fixed [#7](https://github.com/aleksandr-m/gitflow-maven-plugin/issues/7) - Correctly set empty value to Git configuration
 * Improved commands execution
 
-## v1.1.0
+## v1.1.0 (2015-10-07)
 
 * Added support for Eclipse plugins build with Tycho
 * Skipped checking out unnecessary branch when `skipTestProject` is set to true
 * Improved error log
 
-## v1.0.8
+## v1.0.8 (2015-02-10)
 
 * Fixed issue [#3](https://github.com/aleksandr-m/gitflow-maven-plugin/issues/3) - on *nix systems return values from `git for-each-ref` are wrapped in quotes
 * Added null check on getting current project version
 * Small code improvements
 
-## v1.0.7
+## v1.0.7 (2015-01-18)
 
 * Reduced spam to console
 * Added `verbose` parameter
 * Small code improvements
 
-## v1.0.6
+## v1.0.6 (2014-11-06)
 
 * Setting git flow configuration into project git configuration
 * Nicer prompt
 
-## v1.0.5
+## v1.0.5 (2014-08-28)
 
 * Added `installProject` parameter
 * Added `skipTestProject` parameter
 * Added `skipFeatureVersion` parameter
 * Added auto generated `help` goal
 
-## v1.0.1-alpha4
+## v1.0.1-alpha4 (2014-08-09)
 
 * Added support for releasing in non-interactive (batch) mode
 * Small code improvements
 
-## v1.0.1-alpha3
+## v1.0.1-alpha3 (2014-07-11)
 
 * Added `keepBranch` parameter
 * Fixed issue [#1](https://github.com/aleksandr-m/gitflow-maven-plugin/issues/1) - using commands to check for uncommitted changes
 
-## v1.0.1-alpha2
+## v1.0.1-alpha2 (2014-05-12)
 
 * Added `skipTag` parameter
 
-## v1.0.1-alpha1
+## v1.0.1-alpha1 (2014-04-29)
 
 * Initial version


### PR DESCRIPTION
It's always nice to know the dates for the different releases, it avoid to check the commits or the releases tab to match changelog details and version date.