### PR TITLE
Support for Release Branches Version Suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v1.15.0 (2020-01-23)
+* Added `releaseBranchVersionSuffix` parameter in `release-start` and `release-finish`
+
 ## v1.14.0 (2019-12-06)
 
 * Fixed snapshot dependencies check and improved version resolution - [#204](https://github.com/aleksandr-m/gitflow-maven-plugin/pull/204)

--- a/README.md
+++ b/README.md
@@ -250,6 +250,9 @@ The `gitflow:release-start` goal has `fromCommit` parameter which allows to star
 The `gitflow:release-start` and `gitflow:release-finish` goals have `useSnapshotInRelease` parameter which allows to start the release with SNAPSHOT version and finish it without this value in project version. By default the value is `false`.
 For example, if the release version  is `1.0.2` and `useSnapshotInRelease` is set to `true` and using `gitflow:release-start` goal then the release version will be `1.0.2-SNAPSHOT` and when finishing the release with `gitflow:release-finish` goal, the release version will be `1.0.2`
 
+The `gitflow:release-start` and `gitflow:release-finish` goals have `releaseBranchVersionSuffix` parameter which allows to start the release with a suffix appended to the version and finish it without this value in project version. By default the value isn't set.
+For example, if the release version  is `1.0.2` and `releaseBranchVersionSuffix` is set to `RC` and using `gitflow:release-start` goal then the release version will be `1.0.2-RC` and when finishing the release with `gitflow:release-finish` goal, the release version will be `1.0.2`
+
 The `gitflow:hotfix-start` and `gitflow:hotfix-finish` goals have `useSnapshotInHotfix` parameter which allows to start the hotfix with SNAPSHOT version and finish it without this value in the version. By default the value is `false`.
 For example, if the hotfix version  is `1.0.2.1` and `useSnapshotInHotfix` is set to `true` and using `gitflow:hotfix-start` goal then the hotfix version will be `1.0.2.1-SNAPSHOT` and when finishing the release with `gitflow:hotfix-finish` goal, the release version will be `1.0.2.1`
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <artifactId>gitflow-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
     <name>gitflow-maven-plugin</name>
-    <version>1.14.1-SNAPSHOT</version>
+    <version>1.15.0-SNAPSHOT</version>
 
     <description>The Git-Flow Maven Plugin supports various Git workflows, including Vincent Driessen's successful Git branching model and GitHub Flow. This plugin runs Git and Maven commands from the command line. Supports Eclipse Plugins build with Tycho.</description>
 

--- a/src/it/release-finish-7-it/expected-development-pom.xml
+++ b/src/it/release-finish-7-it/expected-development-pom.xml
@@ -1,0 +1,7 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.amashchenko.maven.plugin</groupId>
+    <artifactId>gitflow-maven-test</artifactId>
+    <packaging>pom</packaging>
+    <version>0.0.4-SNAPSHOT</version>
+</project>

--- a/src/it/release-finish-7-it/expected-production-pom.xml
+++ b/src/it/release-finish-7-it/expected-production-pom.xml
@@ -1,0 +1,7 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.amashchenko.maven.plugin</groupId>
+    <artifactId>gitflow-maven-test</artifactId>
+    <packaging>pom</packaging>
+    <version>0.0.3</version>
+</project>

--- a/src/it/release-finish-7-it/gitignorefile
+++ b/src/it/release-finish-7-it/gitignorefile
@@ -1,0 +1,6 @@
+build.log
+expected-development-pom.xml
+expected-production-pom.xml
+invoker.properties
+init.bsh
+verify.bsh

--- a/src/it/release-finish-7-it/init.bsh
+++ b/src/it/release-finish-7-it/init.bsh
@@ -1,0 +1,23 @@
+try {
+    new File(basedir, "gitignorefile").renameTo(new File(basedir, ".gitignore"));
+
+    Process p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " init");
+    p.waitFor();
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " add .");
+    p.waitFor();
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " commit -m init");
+    p.waitFor();
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " branch release/0.0.3");
+    p.waitFor();
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " checkout -b develop");
+    p.waitFor();
+
+} catch (Exception e) {
+    e.printStackTrace();
+    return false;
+}
+return true;

--- a/src/it/release-finish-7-it/invoker.properties
+++ b/src/it/release-finish-7-it/invoker.properties
@@ -1,0 +1,3 @@
+invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:release-finish -DpushRemote=false -DreleaseBranchVersionSuffix=RC
+
+invoker.description=Simple release-finish.

--- a/src/it/release-finish-7-it/pom.xml
+++ b/src/it/release-finish-7-it/pom.xml
@@ -1,0 +1,7 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.amashchenko.maven.plugin</groupId>
+    <artifactId>gitflow-maven-test</artifactId>
+    <packaging>pom</packaging>
+    <version>0.0.3-RC</version>
+</project>

--- a/src/it/release-finish-7-it/verify.bsh
+++ b/src/it/release-finish-7-it/verify.bsh
@@ -1,0 +1,61 @@
+import org.codehaus.plexus.util.FileUtils;
+
+try {
+    File gitTag = new File(basedir, ".git/refs/tags/0.0.3");
+    if (!gitTag.exists()) {
+        System.out.println("release-finish .git/refs/tags/0.0.3 doesn't exist");
+        return false;
+    }
+
+    File gitReleaseRef = new File(basedir, ".git/refs/heads/release/0.0.3");
+    if (gitReleaseRef.exists()) {
+        System.out.println("release-finish .git/refs/heads/release/0.0.3 exists");
+        return false;
+    }
+    File gitDevelopRef = new File(basedir, ".git/refs/heads/develop");
+    if (!gitDevelopRef.exists()) {
+        System.out.println("release-finish .git/refs/heads/develop doesn't exist");
+        return false;
+    }
+    File gitMasterRef = new File(basedir, ".git/refs/heads/master");
+    if (!gitMasterRef.exists()) {
+        System.out.println("release-finish .git/refs/heads/master doesn't exist");
+        return false;
+    }
+
+    File file = new File(basedir, "pom.xml");
+    File expectedFile = new File(basedir, "expected-development-pom.xml");
+
+    String actual = FileUtils.fileRead(file, "UTF-8");
+    String expected = FileUtils.fileRead(expectedFile, "UTF-8");
+
+    actual = actual.replaceAll("\\r?\\n", "");
+    expected = expected.replaceAll("\\r?\\n", "");
+
+    if (!expected.equals(actual)) {
+        System.out.println("release-finish expected: " + expected + " actual was:" + actual);
+        return false;
+    }
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " checkout master");
+    p.waitFor();
+
+    file = new File(basedir, "pom.xml");
+    expectedFile = new File(basedir, "expected-production-pom.xml");
+
+    actual = FileUtils.fileRead(file, "UTF-8");
+    expected = FileUtils.fileRead(expectedFile, "UTF-8");
+
+    actual = actual.replaceAll("\\r?\\n", "");
+    expected = expected.replaceAll("\\r?\\n", "");
+
+    if (!expected.equals(actual)) {
+        System.out.println("release-finish expected: " + expected + " actual was:" + actual);
+        return false;
+    }
+
+} catch (Exception e) {
+    e.printStackTrace();
+    return false;
+}
+return true;

--- a/src/it/release-finish-8-it/expected-development-pom.xml
+++ b/src/it/release-finish-8-it/expected-development-pom.xml
@@ -1,0 +1,7 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.amashchenko.maven.plugin</groupId>
+    <artifactId>gitflow-maven-test</artifactId>
+    <packaging>pom</packaging>
+    <version>0.0.4-SNAPSHOT</version>
+</project>

--- a/src/it/release-finish-8-it/expected-production-pom.xml
+++ b/src/it/release-finish-8-it/expected-production-pom.xml
@@ -1,0 +1,7 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.amashchenko.maven.plugin</groupId>
+    <artifactId>gitflow-maven-test</artifactId>
+    <packaging>pom</packaging>
+    <version>0.0.3</version>
+</project>

--- a/src/it/release-finish-8-it/gitignorefile
+++ b/src/it/release-finish-8-it/gitignorefile
@@ -1,0 +1,6 @@
+build.log
+expected-development-pom.xml
+expected-production-pom.xml
+invoker.properties
+init.bsh
+verify.bsh

--- a/src/it/release-finish-8-it/init.bsh
+++ b/src/it/release-finish-8-it/init.bsh
@@ -1,0 +1,23 @@
+try {
+    new File(basedir, "gitignorefile").renameTo(new File(basedir, ".gitignore"));
+
+    Process p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " init");
+    p.waitFor();
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " add .");
+    p.waitFor();
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " commit -m init");
+    p.waitFor();
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " branch release/0.0.3");
+    p.waitFor();
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " checkout -b develop");
+    p.waitFor();
+
+} catch (Exception e) {
+    e.printStackTrace();
+    return false;
+}
+return true;

--- a/src/it/release-finish-8-it/invoker.properties
+++ b/src/it/release-finish-8-it/invoker.properties
@@ -1,0 +1,3 @@
+invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:release-finish -DpushRemote=false -DuseSnapshotInRelease=true -DreleaseBranchVersionSuffix=RC
+
+invoker.description=Simple release-finish.

--- a/src/it/release-finish-8-it/pom.xml
+++ b/src/it/release-finish-8-it/pom.xml
@@ -1,0 +1,7 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.amashchenko.maven.plugin</groupId>
+    <artifactId>gitflow-maven-test</artifactId>
+    <packaging>pom</packaging>
+    <version>0.0.3-RC-SNAPSHOT</version>
+</project>

--- a/src/it/release-finish-8-it/verify.bsh
+++ b/src/it/release-finish-8-it/verify.bsh
@@ -1,0 +1,61 @@
+import org.codehaus.plexus.util.FileUtils;
+
+try {
+    File gitTag = new File(basedir, ".git/refs/tags/0.0.3");
+    if (!gitTag.exists()) {
+        System.out.println("release-finish .git/refs/tags/0.0.3 doesn't exist");
+        return false;
+    }
+
+    File gitReleaseRef = new File(basedir, ".git/refs/heads/release/0.0.3");
+    if (gitReleaseRef.exists()) {
+        System.out.println("release-finish .git/refs/heads/release/0.0.3 exists");
+        return false;
+    }
+    File gitDevelopRef = new File(basedir, ".git/refs/heads/develop");
+    if (!gitDevelopRef.exists()) {
+        System.out.println("release-finish .git/refs/heads/develop doesn't exist");
+        return false;
+    }
+    File gitMasterRef = new File(basedir, ".git/refs/heads/master");
+    if (!gitMasterRef.exists()) {
+        System.out.println("release-finish .git/refs/heads/master doesn't exist");
+        return false;
+    }
+
+    File file = new File(basedir, "pom.xml");
+    File expectedFile = new File(basedir, "expected-development-pom.xml");
+
+    String actual = FileUtils.fileRead(file, "UTF-8");
+    String expected = FileUtils.fileRead(expectedFile, "UTF-8");
+
+    actual = actual.replaceAll("\\r?\\n", "");
+    expected = expected.replaceAll("\\r?\\n", "");
+
+    if (!expected.equals(actual)) {
+        System.out.println("release-finish expected: " + expected + " actual was:" + actual);
+        return false;
+    }
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " checkout master");
+    p.waitFor();
+
+    file = new File(basedir, "pom.xml");
+    expectedFile = new File(basedir, "expected-production-pom.xml");
+
+    actual = FileUtils.fileRead(file, "UTF-8");
+    expected = FileUtils.fileRead(expectedFile, "UTF-8");
+
+    actual = actual.replaceAll("\\r?\\n", "");
+    expected = expected.replaceAll("\\r?\\n", "");
+
+    if (!expected.equals(actual)) {
+        System.out.println("release-finish expected: " + expected + " actual was:" + actual);
+        return false;
+    }
+
+} catch (Exception e) {
+    e.printStackTrace();
+    return false;
+}
+return true;

--- a/src/it/release-finish-9-it/expected-development-pom.xml
+++ b/src/it/release-finish-9-it/expected-development-pom.xml
@@ -1,0 +1,7 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.amashchenko.maven.plugin</groupId>
+    <artifactId>gitflow-maven-test</artifactId>
+    <packaging>pom</packaging>
+    <version>0.0.4-RC-SNAPSHOT</version>
+</project>

--- a/src/it/release-finish-9-it/expected-production-pom.xml
+++ b/src/it/release-finish-9-it/expected-production-pom.xml
@@ -1,0 +1,7 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.amashchenko.maven.plugin</groupId>
+    <artifactId>gitflow-maven-test</artifactId>
+    <packaging>pom</packaging>
+    <version>0.0.3-RC</version>
+</project>

--- a/src/it/release-finish-9-it/gitignorefile
+++ b/src/it/release-finish-9-it/gitignorefile
@@ -1,0 +1,6 @@
+build.log
+expected-development-pom.xml
+expected-production-pom.xml
+invoker.properties
+init.bsh
+verify.bsh

--- a/src/it/release-finish-9-it/init.bsh
+++ b/src/it/release-finish-9-it/init.bsh
@@ -1,0 +1,23 @@
+try {
+    new File(basedir, "gitignorefile").renameTo(new File(basedir, ".gitignore"));
+
+    Process p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " init");
+    p.waitFor();
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " add .");
+    p.waitFor();
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " commit -m init");
+    p.waitFor();
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " branch release/0.0.3");
+    p.waitFor();
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " checkout -b develop");
+    p.waitFor();
+
+} catch (Exception e) {
+    e.printStackTrace();
+    return false;
+}
+return true;

--- a/src/it/release-finish-9-it/invoker.properties
+++ b/src/it/release-finish-9-it/invoker.properties
@@ -1,0 +1,3 @@
+invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:release-finish -DpushRemote=false -DuseSnapshotInRelease=true
+
+invoker.description=Simple release-finish.

--- a/src/it/release-finish-9-it/pom.xml
+++ b/src/it/release-finish-9-it/pom.xml
@@ -1,0 +1,7 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.amashchenko.maven.plugin</groupId>
+    <artifactId>gitflow-maven-test</artifactId>
+    <packaging>pom</packaging>
+    <version>0.0.3-RC-SNAPSHOT</version>
+</project>

--- a/src/it/release-finish-9-it/verify.bsh
+++ b/src/it/release-finish-9-it/verify.bsh
@@ -1,0 +1,61 @@
+import org.codehaus.plexus.util.FileUtils;
+
+try {
+    File gitTag = new File(basedir, ".git/refs/tags/0.0.3-RC");
+    if (!gitTag.exists()) {
+        System.out.println("release-finish .git/refs/tags/0.0.3-RC doesn't exist");
+        return false;
+    }
+
+    File gitReleaseRef = new File(basedir, ".git/refs/heads/release/0.0.3");
+    if (gitReleaseRef.exists()) {
+        System.out.println("release-finish .git/refs/heads/release/0.0.3 exists");
+        return false;
+    }
+    File gitDevelopRef = new File(basedir, ".git/refs/heads/develop");
+    if (!gitDevelopRef.exists()) {
+        System.out.println("release-finish .git/refs/heads/develop doesn't exist");
+        return false;
+    }
+    File gitMasterRef = new File(basedir, ".git/refs/heads/master");
+    if (!gitMasterRef.exists()) {
+        System.out.println("release-finish .git/refs/heads/master doesn't exist");
+        return false;
+    }
+
+    File file = new File(basedir, "pom.xml");
+    File expectedFile = new File(basedir, "expected-development-pom.xml");
+
+    String actual = FileUtils.fileRead(file, "UTF-8");
+    String expected = FileUtils.fileRead(expectedFile, "UTF-8");
+
+    actual = actual.replaceAll("\\r?\\n", "");
+    expected = expected.replaceAll("\\r?\\n", "");
+
+    if (!expected.equals(actual)) {
+        System.out.println("release-finish expected: " + expected + " actual was:" + actual);
+        return false;
+    }
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " checkout master");
+    p.waitFor();
+
+    file = new File(basedir, "pom.xml");
+    expectedFile = new File(basedir, "expected-production-pom.xml");
+
+    actual = FileUtils.fileRead(file, "UTF-8");
+    expected = FileUtils.fileRead(expectedFile, "UTF-8");
+
+    actual = actual.replaceAll("\\r?\\n", "");
+    expected = expected.replaceAll("\\r?\\n", "");
+
+    if (!expected.equals(actual)) {
+        System.out.println("release-finish expected: " + expected + " actual was:" + actual);
+        return false;
+    }
+
+} catch (Exception e) {
+    e.printStackTrace();
+    return false;
+}
+return true;

--- a/src/it/release-start-4-it/expected-pom.xml
+++ b/src/it/release-start-4-it/expected-pom.xml
@@ -1,0 +1,7 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.amashchenko.maven.plugin</groupId>
+    <artifactId>gitflow-maven-test</artifactId>
+    <packaging>pom</packaging>
+    <version>0.0.3-RC</version>
+</project>

--- a/src/it/release-start-4-it/gitignorefile
+++ b/src/it/release-start-4-it/gitignorefile
@@ -1,0 +1,5 @@
+build.log
+expected-pom.xml
+invoker.properties
+init.bsh
+verify.bsh

--- a/src/it/release-start-4-it/init.bsh
+++ b/src/it/release-start-4-it/init.bsh
@@ -1,0 +1,20 @@
+try {
+    new File(basedir, "gitignorefile").renameTo(new File(basedir, ".gitignore"));
+
+    Process p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " init");
+    p.waitFor();
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " add .");
+    p.waitFor();
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " commit -m init");
+    p.waitFor();
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " checkout -b develop");
+    p.waitFor();
+
+} catch (Exception e) {
+    e.printStackTrace();
+    return false;
+}
+return true;

--- a/src/it/release-start-4-it/invoker.properties
+++ b/src/it/release-start-4-it/invoker.properties
@@ -1,0 +1,3 @@
+invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:release-start -B -DreleaseBranchVersionSuffix=RC
+
+invoker.description=Non-interactive simple release-start.

--- a/src/it/release-start-4-it/pom.xml
+++ b/src/it/release-start-4-it/pom.xml
@@ -1,0 +1,7 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.amashchenko.maven.plugin</groupId>
+    <artifactId>gitflow-maven-test</artifactId>
+    <packaging>pom</packaging>
+    <version>0.0.3-SNAPSHOT</version>
+</project>

--- a/src/it/release-start-4-it/verify.bsh
+++ b/src/it/release-start-4-it/verify.bsh
@@ -1,0 +1,27 @@
+import org.codehaus.plexus.util.FileUtils;
+
+try {
+    File gitRef = new File(basedir, ".git/refs/heads/release/0.0.3");
+    if (!gitRef.exists()) {
+        System.out.println("release-start .git/refs/heads/release/0.0.3 doesn't exist");
+        return false;
+    }
+
+    File file = new File(basedir, "pom.xml");
+    File expectedFile = new File(basedir, "expected-pom.xml");
+
+    String actual = FileUtils.fileRead(file, "UTF-8");
+    String expected = FileUtils.fileRead(expectedFile, "UTF-8");
+
+    actual = actual.replaceAll("\\r?\\n", "");
+    expected = expected.replaceAll("\\r?\\n", "");
+
+    if (!expected.equals(actual)) {
+        System.out.println("release-start expected: " + expected + " actual was:" + actual);
+        return false;
+    }
+} catch (Exception e) {
+    e.printStackTrace();
+    return false;
+}
+return true;

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowReleaseStartMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowReleaseStartMojo.java
@@ -139,6 +139,25 @@ public class GitFlowReleaseStartMojo extends AbstractGitFlowMojo {
     @Parameter(property = "branchName")
     private String branchName;
 
+    /**
+     * Suffix to append to versions on the release branch.<br>
+     *
+     * @since 1.14.1
+     */
+    @Parameter(property = "releaseBranchVersionSuffix", defaultValue = "")
+    private String releaseBranchVersionSuffix = "";
+
+    @Override
+    protected void validateConfiguration(String... params) throws MojoFailureException {
+        super.validateConfiguration(params);
+
+        if (releaseBranchVersionSuffix.compareTo(Artifact.SNAPSHOT_VERSION) == 0) {
+            throw new MojoFailureException(
+                    "Release branch version suffix " +
+                            Artifact.SNAPSHOT_VERSION + " is not allowed.");
+        }
+    }
+
     /** {@inheritDoc} */
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
@@ -202,6 +221,17 @@ public class GitFlowReleaseStartMojo extends AbstractGitFlowMojo {
             }
 
             String projectVersion = releaseVersion;
+            if (StringUtils.isNotBlank(releaseBranchVersionSuffix)) {
+                projectVersion = projectVersion + "-" + releaseBranchVersionSuffix;
+
+                if (mavenSession.getUserProperties().get("releaseBranchVersionSuffix") != null) {
+                    getLog().warn(
+                            "The releaseBranchVersionSuffix parameter is set from the command line."
+                                    + " Don't forget to use it in the finish goal as well."
+                                    + " It is better to define it in the project's pom file.");
+                }
+            }
+
             if (useSnapshotInRelease && !ArtifactUtils.isSnapshot(projectVersion)) {
                 projectVersion = projectVersion + "-" + Artifact.SNAPSHOT_VERSION;
             }


### PR DESCRIPTION
Hi there it would be great if we have support for suffixes on release branches.

This will allow us to produce for instance release candidate branches.

For example we want to create a release branch 1.0.2 that is a release candidate. We set the parameter `releaseBranchVersionSuffix=RC`, when doing a release-start, and RC will be appended to the version number, like 1.0.2-RC

After finishing the release candidate branch the version will be 1.0.2