### PR TITLE
Update snapshots with coresponding releases

### DIFF
--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
@@ -47,6 +47,8 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
     private static final String VERSIONS_MAVEN_PLUGIN_SET_GOAL = "org.codehaus.mojo:versions-maven-plugin:set";
     /** A full name of the versions-maven-plugin set-property goal. */
     private static final String VERSIONS_MAVEN_PLUGIN_SET_PROPERTY_GOAL = "org.codehaus.mojo:versions-maven-plugin:set-property";
+    /** A full name of the versions-maven-plugin use-releases goal. */
+    private static final String VERSIONS_MAVEN_PLUGIN_USE_RELEASES_GOAL = "org.codehaus.mojo:versions-maven-plugin:use-releases";
     /** Name of the tycho-versions-plugin set-version goal. */
     private static final String TYCHO_VERSIONS_PLUGIN_SET_GOAL = "org.eclipse.tycho:tycho-versions-plugin:set-version";
 
@@ -1014,6 +1016,17 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
                         "-DgenerateBackupPoms=false");
             }
         }
+    }
+
+    /**
+     * Executes 'use-releases' goal of versions-maven-plugin.
+     *
+     * @throws MojoFailureException
+     * @throws CommandLineException
+     */
+    protected void mvnUseReleases() throws MojoFailureException, CommandLineException {
+        getLog().info("Searching the pom for all -SNAPSHOT versions which have been released and replacing them with the corresponding release version.");
+        executeMvnCommand(VERSIONS_MAVEN_PLUGIN_USE_RELEASES_GOAL, "-DgenerateBackupPoms=false");
     }
 
     /**

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
@@ -16,6 +16,7 @@
 package com.amashchenko.maven.plugin.gitflow;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -738,6 +739,19 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
             final Map<String, String> messageProperties)
             throws MojoFailureException, CommandLineException {
         gitMerge(branchName, false, true, false, message, messageProperties);
+    }
+
+    /**
+     * Executes git merge --ff-only.
+     *
+     * @param branchName
+     *            Branch name to merge.
+     * @throws MojoFailureException
+     * @throws CommandLineException
+     */
+    protected void gitMergeFfOnly(final String branchName)
+            throws MojoFailureException, CommandLineException {
+        gitMerge(branchName, false, false, true, "", new HashMap<String, String>());
     }
 
     /**

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
@@ -290,6 +290,10 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
         }
     }
 
+    protected boolean hasUncommittedChanges() throws CommandLineException, MojoFailureException {
+        return executeGitHasUncommitted();
+    }
+
     protected void checkSnapshotDependencies() throws MojoFailureException {
         getLog().info("Checking for SNAPSHOT versions in dependencies.");
 
@@ -318,6 +322,19 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
             throw new MojoFailureException(
                     "There is some SNAPSHOT dependencies in the project, see warnings above. Change them or ignore with `allowSnapshots` property.");
         }
+    }
+
+    protected void checkSnapshotDependenciesWithoutCorrespondingReleases()
+            throws MojoFailureException, CommandLineException {
+
+        mvnUseReleases();
+        try {
+            checkSnapshotDependencies();
+        } catch (MojoFailureException exception) {
+            gitReset();
+            throw exception;
+        }
+        gitReset();
     }
 
     /**
@@ -795,6 +812,19 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
             executeGitCommand("tag", "-a", tagName, "-m", message);
         }
+    }
+
+    /**
+     * Executes git reset --hard
+     *
+     * @throws MojoFailureException
+     * @throws CommandLineException
+     */
+    protected void gitReset()
+            throws MojoFailureException, CommandLineException {
+        getLog().info("Resetting uncommited changes.");
+
+        executeGitCommand("reset", "--hard");
     }
 
     /**

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/CommitMessages.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/CommitMessages.java
@@ -52,6 +52,8 @@ public class CommitMessages {
     private String updateReleaseToAvoidConflictsMessage;
     private String updateReleaseBackPreMergeStateMessage;
 
+    private String replaceSnapshotDependenciesMessage;
+
     public CommitMessages() {
         featureStartMessage = "Update versions for feature branch";
         featureFinishMessage = "Update versions for development branch";
@@ -77,6 +79,8 @@ public class CommitMessages {
 
         updateReleaseToAvoidConflictsMessage = "Update release to hotfix version to avoid merge conflicts";
         updateReleaseBackPreMergeStateMessage = "Update release version back to pre-merge state";
+
+        replaceSnapshotDependenciesMessage = "Replace all released -SNAPSHOT dependencies with the corresponding release versions";
     }
 
     /**
@@ -386,5 +390,20 @@ public class CommitMessages {
      */
     public void setFeatureFinishDevMergeMessage(String featureFinishDevMergeMessage) {
         this.featureFinishDevMergeMessage = featureFinishDevMergeMessage;
+    }
+
+    /**
+     * @return the replaceSnapshotDependenciesMessage
+     */
+    public String getReplaceSnapshotDependenciesMessage() {
+        return replaceSnapshotDependenciesMessage;
+    }
+
+    /**
+     * @param replaceSnapshotDependenciesMessage
+     *            the replaceSnapshotDependenciesMessage to set
+     */
+    public void setReplaceSnapshotDependenciesMessage(String replaceSnapshotDependenciesMessage) {
+        this.replaceSnapshotDependenciesMessage = replaceSnapshotDependenciesMessage;
     }
 }

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowReleaseStartMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowReleaseStartMojo.java
@@ -189,7 +189,11 @@ public class GitFlowReleaseStartMojo extends AbstractGitFlowMojo {
 
             // check snapshots dependencies
             if (!allowSnapshots) {
-                checkSnapshotDependencies();
+                if (updateSnapshotDependencies) {
+                    checkSnapshotDependenciesWithoutCorrespondingReleases();
+                } else {
+                    checkSnapshotDependencies();
+                }
             }
 
             if (commitDevelopmentVersionAtStart && !notSameProdDevName()) {
@@ -336,7 +340,9 @@ public class GitFlowReleaseStartMojo extends AbstractGitFlowMojo {
 
     private void commitReleasedDependencies() throws CommandLineException, MojoFailureException {
         mvnUseReleases();
-        gitCommit(commitMessages.getReplaceSnapshotDependenciesMessage());
+        if (hasUncommittedChanges()) {
+            gitCommit(commitMessages.getReplaceSnapshotDependenciesMessage());
+        }
     }
 
     private void commitProjectVersion(String version, String commitMessage)

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowReleaseStartMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowReleaseStartMojo.java
@@ -233,7 +233,10 @@ public class GitFlowReleaseStartMojo extends AbstractGitFlowMojo {
 
             if (updateSnapshotDependencies) {
                 // mvn versions:use-releases ...
-                commitReleasedDependencies();
+                mvnUseReleases();
+                if (hasUncommittedChanges()) {
+                    gitCommit(commitMessages.getReplaceSnapshotDependenciesMessage());
+                }
             }
 
             if (commitDevelopmentVersionAtStart) {
@@ -336,13 +339,6 @@ public class GitFlowReleaseStartMojo extends AbstractGitFlowMojo {
         }
 
         return version;
-    }
-
-    private void commitReleasedDependencies() throws CommandLineException, MojoFailureException {
-        mvnUseReleases();
-        if (hasUncommittedChanges()) {
-            gitCommit(commitMessages.getReplaceSnapshotDependenciesMessage());
-        }
     }
 
     private void commitProjectVersion(String version, String commitMessage)


### PR DESCRIPTION
This feature allows replacing all released -SNAPSHOT dependencies with the corresponding release versions. The feature is optional and can be activated with optional parameter: 

`<updateSnapshotDependencies>true</updateSnapshotDependencies>`