### PR TITLE
#232 Support interactive input for next development version (optional)

### DIFF
--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowHotfixStartMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowHotfixStartMojo.java
@@ -164,22 +164,7 @@ public class GitFlowHotfixStartMojo extends AbstractGitFlowMojo {
 
             String version = null;
             if (settings.isInteractiveMode()) {
-                try {
-                    while (version == null) {
-                        version = prompter
-                                .prompt("What is the hotfix version? ["
-                                        + defaultVersion + "]");
-
-                        if (!"".equals(version)
-                                && (!GitFlowVersionInfo.isValidVersion(version)
-                                        || !validBranchName(version))) {
-                            getLog().info("The version is not valid.");
-                            version = null;
-                        }
-                    }
-                } catch (PrompterException e) {
-                    throw new MojoFailureException("hotfix-start", e);
-                }
+                version = promptForVersion("What is the hotfix version?", defaultVersion);
             } else {
                 if (StringUtils.isNotBlank(hotfixVersion)
                         && (!GitFlowVersionInfo.isValidVersion(hotfixVersion)


### PR DESCRIPTION
PR for #232 

this also eliminates a bit code redundancy for prompting for versions and getting next snapshot versions in the different goal implementations