### PR TITLE
Allow user to force using the current develop branch version when merging a feature

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <artifactId>gitflow-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
     <name>gitflow-maven-plugin</name>
-    <version>1.14.1-SNAPSHOT</version>
+    <version>1.14.2</version>
 
     <description>The Git-Flow Maven Plugin supports various Git workflows, including Vincent Driessen's successful Git branching model and GitHub Flow. This plugin runs Git and Maven commands from the command line. Supports Eclipse Plugins build with Tycho.</description>
 
@@ -50,20 +50,22 @@
     </scm>
 
     <distributionManagement>
-        <repository>
-            <id>sonatype-nexus-staging</id>
-            <name>Nexus Release Repository</name>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
         <snapshotRepository>
-            <id>sonatype-nexus-snapshots</id>
-            <name>Sonatype Nexus Snapshots</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <id>JGSNAP</id>
+            <url>https://mvn.jini.guru/artifactory/libs-snapshot</url>
         </snapshotRepository>
+        <repository>
+            <id>JGREL</id>
+            <url>https://mvn.jini.guru/artifactory/libs-release</url>
+        </repository>
+        <site>
+            <id>jg-arch-site</id>
+            <url>file://${main.basedir}/target</url>
+        </site>
     </distributionManagement>
 
     <properties>
-        <java.version>1.6</java.version>
+        <java.version>11</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <scm.url>scm:git:git@github.com:aleksandr-m/gitflow-maven-plugin.git</scm.url>
         <url>https://github.com/aleksandr-m/gitflow-maven-plugin</url>
@@ -90,7 +92,7 @@
                     </reportSet>
                 </reportSets>
                 <configuration>
-                   <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
+                    <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <artifactId>gitflow-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
     <name>gitflow-maven-plugin</name>
-    <version>1.14.2</version>
+    <version>20.0.1</version>
 
     <description>The Git-Flow Maven Plugin supports various Git workflows, including Vincent Driessen's successful Git branching model and GitHub Flow. This plugin runs Git and Maven commands from the command line. Supports Eclipse Plugins build with Tycho.</description>
 

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
@@ -491,7 +491,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
         // https://github.com/aleksandr-m/gitflow-maven-plugin/issues/3
         branches = removeQuotes(branches);
         branches = StringUtils.strip(branches);
-
+        getLog().info("Found branches: " + branches);
         return branches;
     }
 
@@ -961,6 +961,20 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
         }
     }
 
+    protected void gitPrune()
+            throws MojoFailureException, CommandLineException {
+        getLog().info("Pruning detached branches");
+
+        executeGitCommand("remote", "prune", "origin");
+    }
+
+    protected void gitPullAll()
+            throws MojoFailureException, CommandLineException {
+        getLog().info("Pulling all branches");
+
+        executeGitCommand("pull", "--all");
+    }
+
     /**
      * Executes 'set' goal of versions-maven-plugin or 'set-version' of tycho-versions-plugin in case it is tycho build.
      *
@@ -1128,6 +1142,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
         final CommandLineUtils.StringStreamConsumer err = new CommandLineUtils.StringStreamConsumer();
 
+        getLog().debug("Running: " + cmd.toString());
         // execute
         final int exitCode = CommandLineUtils.executeCommandLine(cmd, out, err);
 

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowFeatureFinishMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowFeatureFinishMojo.java
@@ -94,8 +94,8 @@ public class GitFlowFeatureFinishMojo extends AbstractGitFlowMojo {
      *
      * @since 1.14.1
      */
-    @Parameter(property = "retainDevelopVersion", defaultValue = "false")
-    private boolean retainDevelopVersion = false;
+    @Parameter(property = "retainDevelopVersion", defaultValue = "true")
+    private boolean retainDevelopVersion = true;
 
     /** {@inheritDoc} */
     @Override

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowFeatureFinishMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowFeatureFinishMojo.java
@@ -237,7 +237,7 @@ public class GitFlowFeatureFinishMojo extends AbstractGitFlowMojo {
         final String currentBranch = gitCurrentBranch();
 
         if (StringUtils.isBlank(featureBranches)) {
-            throw new MojoFailureException("There are no feature branches.");
+            throw new MojoFailureException("There are no feature branches locally - perhaps check out the branch first if its remote so it can be found locally");
         }
 
         final String[] branches = featureBranches.split("\\r?\\n");

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowHotfixFinishMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowHotfixFinishMojo.java
@@ -15,6 +15,7 @@
  */
 package com.amashchenko.maven.plugin.gitflow;
 
+import com.google.common.base.Strings;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -126,6 +127,7 @@ public class GitFlowHotfixFinishMojo extends AbstractGitFlowMojo {
         try {
             // check uncommitted changes
             checkUncommittedChanges();
+            gitPullAll();
 
             String hotfixBranchName = null;
             if (settings.isInteractiveMode()) {
@@ -368,7 +370,7 @@ public class GitFlowHotfixFinishMojo extends AbstractGitFlowMojo {
         }
 
         if (StringUtils.isBlank(hotfixBranches)) {
-            throw new MojoFailureException("There are no hotfix branches.");
+            throw new MojoFailureException("There are no hotfix branches locally - perhaps check out the branch first if its remote so it can be found locally");
         }
 
         String[] branches = hotfixBranches.split("\\r?\\n");

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowHotfixStartMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowHotfixStartMojo.java
@@ -15,6 +15,7 @@
  */
 package com.amashchenko.maven.plugin.gitflow;
 
+import com.google.common.base.Strings;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -33,23 +34,22 @@ import org.codehaus.plexus.util.cli.CommandLineException;
 
 /**
  * The git flow hotfix start mojo.
- * 
+ *
  */
 @Mojo(name = "hotfix-start", aggregator = true)
 public class GitFlowHotfixStartMojo extends AbstractGitFlowMojo {
 
     /**
      * Whether to push to the remote.
-     * 
+     *
      * @since 1.6.0
      */
     @Parameter(property = "pushRemote", defaultValue = "false")
     private boolean pushRemote;
 
     /**
-     * Branch to start hotfix in non-interactive mode. Production branch or one of
-     * the support branches.
-     * 
+     * Branch to start hotfix in non-interactive mode. Production branch or one of the support branches.
+     *
      * @since 1.9.0
      */
     @Parameter(property = "fromBranch")
@@ -57,7 +57,7 @@ public class GitFlowHotfixStartMojo extends AbstractGitFlowMojo {
 
     /**
      * Hotfix version to use in non-interactive mode.
-     * 
+     *
      * @since 1.9.0
      */
     @Parameter(property = "hotfixVersion")
@@ -65,13 +65,15 @@ public class GitFlowHotfixStartMojo extends AbstractGitFlowMojo {
 
     /**
      * Whether to use snapshot in hotfix.
-     * 
+     *
      * @since 1.10.0
      */
     @Parameter(property = "useSnapshotInHotfix", defaultValue = "false")
     private boolean useSnapshotInHotfix;
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         validateConfiguration();
@@ -172,7 +174,7 @@ public class GitFlowHotfixStartMojo extends AbstractGitFlowMojo {
 
                         if (!"".equals(version)
                                 && (!GitFlowVersionInfo.isValidVersion(version)
-                                        || !validBranchName(version))) {
+                                || !validBranchName(version))) {
                             getLog().info("The version is not valid.");
                             version = null;
                         }
@@ -183,7 +185,7 @@ public class GitFlowHotfixStartMojo extends AbstractGitFlowMojo {
             } else {
                 if (StringUtils.isNotBlank(hotfixVersion)
                         && (!GitFlowVersionInfo.isValidVersion(hotfixVersion)
-                                || !validBranchName(hotfixVersion))) {
+                        || !validBranchName(hotfixVersion))) {
                     throw new MojoFailureException("The hotfix version '"
                             + hotfixVersion + "' is not valid.");
                 } else {
@@ -228,7 +230,7 @@ public class GitFlowHotfixStartMojo extends AbstractGitFlowMojo {
                 if (useSnapshotInHotfix && mavenSession.getUserProperties().get("useSnapshotInHotfix") != null) {
                     getLog().warn(
                             "The useSnapshotInHotfix parameter is set from the command line. Don't forget to use it in the finish goal as well."
-                                    + " It is better to define it in the project's pom file.");
+                            + " It is better to define it in the project's pom file.");
                 }
 
                 // mvn versions:set -DnewVersion=... -DgenerateBackupPoms=false

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowReleaseFinishMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowReleaseFinishMojo.java
@@ -33,11 +33,15 @@ import org.codehaus.plexus.util.StringUtils;
 @Mojo(name = "release-finish", aggregator = true)
 public class GitFlowReleaseFinishMojo extends AbstractGitFlowMojo {
 
-    /** Whether to skip tagging the release in Git. */
+    /**
+     * Whether to skip tagging the release in Git.
+     */
     @Parameter(property = "skipTag", defaultValue = "false")
     private boolean skipTag = false;
 
-    /** Whether to keep release branch after finish. */
+    /**
+     * Whether to keep release branch after finish.
+     */
     @Parameter(property = "keepBranch", defaultValue = "false")
     private boolean keepBranch = false;
 
@@ -58,8 +62,7 @@ public class GitFlowReleaseFinishMojo extends AbstractGitFlowMojo {
     private boolean allowSnapshots = false;
 
     /**
-     * Whether to rebase branch or merge. If <code>true</code> then rebase will
-     * be performed.
+     * Whether to rebase branch or merge. If <code>true</code> then rebase will be performed.
      *
      * @since 1.2.3
      */
@@ -99,8 +102,7 @@ public class GitFlowReleaseFinishMojo extends AbstractGitFlowMojo {
     private boolean digitsOnlyDevVersion = false;
 
     /**
-     * Development version to use instead of the default next development
-     * version in non interactive mode.
+     * Development version to use instead of the default next development version in non interactive mode.
      *
      * @since 1.6.0
      */
@@ -108,8 +110,7 @@ public class GitFlowReleaseFinishMojo extends AbstractGitFlowMojo {
     private String developmentVersion = "";
 
     /**
-     * Which digit to increment in the next development version. Starts from
-     * zero.
+     * Which digit to increment in the next development version. Starts from zero.
      *
      * @since 1.6.0
      */
@@ -117,9 +118,8 @@ public class GitFlowReleaseFinishMojo extends AbstractGitFlowMojo {
     private Integer versionDigitToIncrement;
 
     /**
-     * Whether to commit development version when starting the release (vs when
-     * finishing the release which is the default). Has effect only when there
-     * are separate development and production branches.
+     * Whether to commit development version when starting the release (vs when finishing the release which is the default). Has effect only when there are separate development and production
+     * branches.
      *
      * @since 1.7.0
      */
@@ -127,8 +127,7 @@ public class GitFlowReleaseFinishMojo extends AbstractGitFlowMojo {
     private boolean commitDevelopmentVersionAtStart;
 
     /**
-     * Maven goals to execute in the release branch before merging into the
-     * production branch.
+     * Maven goals to execute in the release branch before merging into the production branch.
      *
      * @since 1.8.0
      */
@@ -159,7 +158,9 @@ public class GitFlowReleaseFinishMojo extends AbstractGitFlowMojo {
     @Parameter(property = "useSnapshotInRelease", defaultValue = "false")
     private boolean useSnapshotInRelease;
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         validateConfiguration(preReleaseGoals, postReleaseGoals);
@@ -167,6 +168,10 @@ public class GitFlowReleaseFinishMojo extends AbstractGitFlowMojo {
         try {
             // check uncommitted changes
             checkUncommittedChanges();
+            
+            gitPullAll();
+            gitPrune();
+            
 
             // git for-each-ref --format='%(refname:short)' refs/heads/release/*
             String releaseBranch = gitFindBranches(gitFlowConfig.getReleaseBranchPrefix(), false).trim();
@@ -184,7 +189,7 @@ public class GitFlowReleaseFinishMojo extends AbstractGitFlowMojo {
 
                     if (StringUtils.countMatches(releaseBranch, gitFlowConfig.getReleaseBranchPrefix()) > 1) {
                         throw new MojoFailureException(
-                                "More than one remote release branch exists. Cannot finish release.");
+                                "More than one remote release branch exists. Cannot finish release. [" + gitFlowConfig.getReleaseBranchPrefix() + "] is found more than once in [" + releaseBranch + "]");
                     }
 
                     gitCreateAndCheckout(releaseBranch, gitFlowConfig.getOrigin() + "/" + releaseBranch);


### PR DESCRIPTION
This is a fix for https://github.com/aleksandr-m/gitflow-maven-plugin/issues/238

Also note this is not just new functionality. This also fixes a bug where the feature version was not being correctly handled if skipTestProject=true