### PR TITLE
Maven Wrapper mvnw and mvnw.cmd built-in support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,8 +63,13 @@
     </distributionManagement>
 
     <properties>
-        <java.version>1.7</java.version>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.custom.encoding>UTF-8</project.custom.encoding>
+        <project.custom.java.version>1.7</project.custom.java.version>
+        <maven.compiler.source>${project.custom.java.version}</maven.compiler.source>
+        <maven.compiler.target>${project.custom.java.version}</maven.compiler.target>
+        <project.build.outputEncoding>${project.custom.encoding}</project.build.outputEncoding>
+        <project.build.sourceEncoding>${project.custom.encoding}</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>${project.custom.encoding}</project.reporting.outputEncoding>
         <maven-plugin-plugin.version>3.6.0</maven-plugin-plugin.version>
     </properties>
 
@@ -100,11 +105,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
-                <configuration>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
-                    <encoding>${project.build.sourceEncoding}</encoding>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
@@ -15,6 +15,7 @@
  */
 package com.amashchenko.maven.plugin.gitflow;
 
+import java.io.File;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -25,6 +26,7 @@ import java.util.Map.Entry;
 import java.util.TimeZone;
 import java.util.regex.Pattern;
 
+import org.apache.commons.lang3.SystemUtils;
 import org.apache.maven.artifact.ArtifactUtils;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Dependency;
@@ -205,7 +207,15 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
     private void initExecutables() {
         if (StringUtils.isBlank(cmdMvn.getExecutable())) {
             if (StringUtils.isBlank(mvnExecutable)) {
-                mvnExecutable = "mvn";
+                if (SystemUtils.IS_OS_UNIX
+                        && new File(".", "mvnw").isFile()) {
+                    mvnExecutable = "./mvnw";
+                } else if (SystemUtils.IS_OS_WINDOWS
+                        && new File(".", "mvnw.cmd").isFile()) {
+                    mvnExecutable = "mvnw.cmd";
+                } else {
+                    mvnExecutable = "mvn";
+                }
             }
             cmdMvn.setExecutable(mvnExecutable);
         }


### PR DESCRIPTION
If `mvnExecutable` is blank, then automatically use `mvnw` or `mvnw.cmd` depending upon OS, if avaliable.

Tested on Mac, that if `mvnw` is present then the current working directory will be used instead of just `mvn`.