### PR TITLE
Add GitHub Actions build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,3 +31,7 @@ jobs:
 
       - name: Run integration test
         run: mvn verify --batch-mode -DskipTests -Prun-its
+
+      - name: Print failed integration test logs
+        if: ${{ failure() }}
+        run: cat target/it/*/build.log

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,33 @@
+name: Main build
+
+on: push
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 6
+        uses: actions/setup-java@v1
+        with:
+          java-version: 6
+
+      - name: Cache Maven
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository/
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven-
+
+      - name: Compile
+        run: mvn compile --batch-mode
+
+      - name: Run tests
+        run: mvn test --batch-mode
+
+      - name: Run integration test
+        run: mvn invoker:run --batch-mode --activate-profiles run-its

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,4 +30,4 @@ jobs:
         run: mvn test --batch-mode
 
       - name: Run integration test
-        run: mvn invoker:run --batch-mode --activate-profiles run-its
+        run: mvn verify --batch-mode -DskipTests -Prun-its

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,10 +11,10 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v2
 
-      - name: Set up JDK 6
+      - name: Set up JDK 7
         uses: actions/setup-java@v1
         with:
-          java-version: 6
+          java-version: 7
 
       - name: Cache Maven
         uses: actions/cache@v2

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Git-Flow Maven Plugin
 
+![.github/workflows/build.yml](https://github.com/aleksandr-m/gitflow-maven-plugin/workflows/.github/workflows/build.yml/badge.svg)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.amashchenko.maven.plugin/gitflow-maven-plugin/badge.svg?subject=Maven%20Central)](https://maven-badges.herokuapp.com/maven-central/com.amashchenko.maven.plugin/gitflow-maven-plugin/)
 [![License](https://img.shields.io/badge/License-Apache%20License%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0.html)
 

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     </distributionManagement>
 
     <properties>
-        <java.version>1.6</java.version>
+        <java.version>1.7</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <scm.url>scm:git:git@github.com:aleksandr-m/gitflow-maven-plugin.git</scm.url>
         <url>https://github.com/aleksandr-m/gitflow-maven-plugin</url>

--- a/src/it/support-start-it/verify.bsh
+++ b/src/it/support-start-it/verify.bsh
@@ -1,9 +1,9 @@
 import org.codehaus.plexus.util.FileUtils;
 
 try {
-    File gitRef = new File(basedir, ".git/refs/heads/support/0.0.3");
+    File gitRef = new File(basedir, ".git/refs/heads/support/0.0.1");
     if (!gitRef.exists()) {
-        System.out.println("support-start .git/refs/heads/support/0.0.3 doesn't exist");
+        System.out.println("support-start .git/refs/heads/support/0.0.1 doesn't exist");
         return false;
     }
 


### PR DESCRIPTION
While getting familiar with the project for #250, I thought I'd start with contributing a CI build (couldn't finde one?) via GitHub Actions.

There are two issues, which I also experience locally:

* The POM says Java version 6, although a dependency (`org.codehaus.plexus.classworlds.launcher.Launcher`) requires 7. (See [this build](https://github.com/beatngu13/gitflow-maven-plugin/runs/1016266717?check_suite_focus=true#step:5:9).)

* The integration tests are failing and I couldn't find a contributing guide or similar to see what is necessary to make them pass. (See [this build](https://github.com/beatngu13/gitflow-maven-plugin/runs/1016275688?check_suite_focus=true#step:7:303).)

What's your take on these?