### PR TITLE
do not append support branch name to hotfix branch. 

### DIFF
--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowHotfixStartMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowHotfixStartMojo.java
@@ -201,10 +201,6 @@ public class GitFlowHotfixStartMojo extends AbstractGitFlowMojo {
 
             String hotfixBranchName = gitFlowConfig.getHotfixBranchPrefix()
                     + branchVersionPart;
-            if (!gitFlowConfig.getProductionBranch().equals(branchName)) {
-                hotfixBranchName = gitFlowConfig.getHotfixBranchPrefix()
-                        + branchName + "/" + branchVersionPart;
-            }
 
             // git for-each-ref refs/heads/hotfix/...
             final boolean hotfixBranchExists = gitCheckBranchExists(


### PR DESCRIPTION
do not append support branch name to hotfix branch. keep format of hotfix branch as hotfix/<version> whether created from production or support branch.
#257 