### PR TITLE
Adding option to feature finish the current branch in batch mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,8 @@ The `gitflow:release-finish` and `gitflow:release` goals have `developmentVersio
 
 The `gitflow:feature-start` and `gitflow:feature-finish` goals have `featureName` parameter which can be used to set a name of the feature in non-interactive mode.
 
+The `gitflow:feature-finish` goal additionally has the `finishCurrentBranch` parameter, which can be set to `true` to finish the current branch in non-interactive mode. Default is `false`.
+
 ## Non-interactive Hotfix
 
 The `gitflow:hotfix-start` goal has `fromBranch` parameter which can be used to set starting branch of the hotfix. It can be set to production branch or one of the support branches.

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowFeatureFinishMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowFeatureFinishMojo.java
@@ -98,7 +98,7 @@ public class GitFlowFeatureFinishMojo extends AbstractGitFlowMojo {
     private boolean incrementVersionAtFinish;
 
     /**
-     * Whether to increment the version during feature-finish goal.
+     * Whether to finish the current branch in non-interactive mode.
      *
      * @since 1.16.0
      */

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowFeatureFinishMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowFeatureFinishMojo.java
@@ -97,6 +97,14 @@ public class GitFlowFeatureFinishMojo extends AbstractGitFlowMojo {
     @Parameter(property = "incrementVersionAtFinish", defaultValue = "false")
     private boolean incrementVersionAtFinish;
 
+    /**
+     * Whether to increment the version during feature-finish goal.
+     *
+     * @since 1.16.0
+     */
+    @Parameter(property = "incrementVersionAtFinish", defaultValue = "false")
+    private boolean finishCurrentBranch;
+
     /** {@inheritDoc} */
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
@@ -118,6 +126,16 @@ public class GitFlowFeatureFinishMojo extends AbstractGitFlowMojo {
                             + "' doesn't exist. Cannot finish feature.");
                 }
                 featureBranchName = branch;
+            } else if (finishCurrentBranch) {
+                final String currentBranch = gitCurrentBranch();
+                if(!currentBranch.startsWith(gitFlowConfig.getFeatureBranchPrefix())) {
+                    throw new MojoFailureException("Current branch with name '"
+                            + currentBranch
+                            + "' is not a feature branch. It does not start with '"
+                            + gitFlowConfig.getFeatureBranchPrefix()
+                            + "'. Cannot finish feature.");
+                }
+                featureBranchName = currentBranch;
             }
 
             if (StringUtils.isBlank(featureBranchName)) {

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowFeatureFinishMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowFeatureFinishMojo.java
@@ -102,7 +102,7 @@ public class GitFlowFeatureFinishMojo extends AbstractGitFlowMojo {
      *
      * @since 1.16.0
      */
-    @Parameter(property = "incrementVersionAtFinish", defaultValue = "false")
+    @Parameter(property = "finishCurrentBranch", defaultValue = "false")
     private boolean finishCurrentBranch;
 
     /** {@inheritDoc} */


### PR DESCRIPTION
Adding the property `finishCurrentBranch` to the `feature-finish` goal. Addresses issue #270.