### PR TITLE
Udpate versions (pom and property) in the same run

### DIFF
--- a/src/it/hotfix-finish-it-3/child1/pom.xml
+++ b/src/it/hotfix-finish-it-3/child1/pom.xml
@@ -1,0 +1,12 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    
+    <parent>
+        <groupId>com.amashchenko.maven.plugin</groupId>
+        <artifactId>gitflow-maven-test</artifactId>
+        <version>1.0</version>
+    </parent>
+    
+    <artifactId>gitflow-maven-test-child1</artifactId>
+    <packaging>pom</packaging>
+</project>

--- a/src/it/hotfix-finish-it-3/child2/pom.xml
+++ b/src/it/hotfix-finish-it-3/child2/pom.xml
@@ -1,0 +1,24 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    
+    <parent>
+        <groupId>com.amashchenko.maven.plugin</groupId>
+        <artifactId>gitflow-maven-test</artifactId>
+        <version>1.0</version>
+    </parent>
+    
+    <artifactId>gitflow-maven-test-child2</artifactId>
+    <packaging>pom</packaging>
+    
+    <dependencyManagement>
+        <dependencies>
+                <dependency>
+                    <groupId>com.amashchenko.maven.plugin</groupId>
+                    <artifactId>gitflow-maven-test-child1</artifactId>
+                    <version>${test.project.version}</version>
+                    <type>pom</type>
+                    <scope>import</scope>
+                </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/src/it/hotfix-finish-it-3/expected-production-pom.xml
+++ b/src/it/hotfix-finish-it-3/expected-production-pom.xml
@@ -1,0 +1,16 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.amashchenko.maven.plugin</groupId>
+    <artifactId>gitflow-maven-test</artifactId>
+    <packaging>pom</packaging>
+    <version>1.0.1</version>
+    
+    <modules>
+        <module>child1</module>
+        <module>child2</module>
+    </modules>
+    
+    <properties>
+        <test.project.version>1.0.1</test.project.version>
+    </properties>
+</project>

--- a/src/it/hotfix-finish-it-3/gitignorefile
+++ b/src/it/hotfix-finish-it-3/gitignorefile
@@ -1,0 +1,7 @@
+build.log
+expected-development-pom.xml
+expected-production-pom.xml
+expected-release-pom.xml
+invoker.properties
+init.bsh
+verify.bsh

--- a/src/it/hotfix-finish-it-3/init.bsh
+++ b/src/it/hotfix-finish-it-3/init.bsh
@@ -1,0 +1,42 @@
+import org.codehaus.plexus.util.FileUtils;
+
+try {
+    new File(basedir, "gitignorefile").renameTo(new File(basedir, ".gitignore"));
+
+    Process p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " init");
+    p.waitFor();
+
+    Process p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " config user.email 'a@a.aa'");
+    p.waitFor();
+    Process p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " config user.name 'a'");
+    p.waitFor();
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " add .");
+    p.waitFor();
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " commit -m init");
+    p.waitFor();
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " branch hotfix/1.0.1");
+    p.waitFor();
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " checkout hotfix/1.0.1");
+    p.waitFor();
+
+    for (String fileName : new String[] {"pom.xml", "child1/pom.xml", "child2/pom.xml"}) {
+        File pomfile = new File(basedir, fileName);
+        String pomfilestr = FileUtils.fileRead(pomfile, "UTF-8");
+        pomfilestr = pomfilestr.replaceAll("1.0", "1.0.1-SNAPSHOT");
+        FileUtils.fileWrite(basedir + "/" + fileName, "UTF-8", pomfilestr);
+    }
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " add .");
+    p.waitFor();
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " commit -m next");
+    p.waitFor();
+
+} catch (Exception e) {
+    e.printStackTrace();
+    return false;
+}
+return true;

--- a/src/it/hotfix-finish-it-3/invoker.properties
+++ b/src/it/hotfix-finish-it-3/invoker.properties
@@ -1,0 +1,3 @@
+invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:hotfix-finish -DpushRemote=false -DfetchRemote=false -B -DhotfixVersion=1.0.1 -DuseSnapshotInHotfix=true -DskipMergeDevBranch=true -DversionProperty=test.project.version
+
+invoker.description=Check that versions:set and versions:set-property are applied in the same run. Otherwise, hotfix-finish fails on versions:set-property as pom version is inconsistent (mixed 1.0.1-SNAPSHOT and 1.0.1).

--- a/src/it/hotfix-finish-it-3/pom.xml
+++ b/src/it/hotfix-finish-it-3/pom.xml
@@ -1,0 +1,16 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.amashchenko.maven.plugin</groupId>
+    <artifactId>gitflow-maven-test</artifactId>
+    <packaging>pom</packaging>
+    <version>1.0</version>
+    
+    <modules>
+        <module>child1</module>
+        <module>child2</module>
+    </modules>
+    
+    <properties>
+        <test.project.version>1.0</test.project.version>
+    </properties>
+</project>

--- a/src/it/hotfix-finish-it-3/verify.bsh
+++ b/src/it/hotfix-finish-it-3/verify.bsh
@@ -1,0 +1,37 @@
+import org.codehaus.plexus.util.FileUtils;
+
+try {
+
+    File gitTag = new File(basedir, ".git/refs/tags/1.0.1");
+    if (!gitTag.exists()) {
+        System.out.println("hotfix-finish .git/refs/tags/1.0.1 does not exist");
+        return false;
+    }
+    File gitMasterRef = new File(basedir, ".git/refs/heads/master");
+    if (!gitMasterRef.exists()) {
+        System.out.println("hotfix-finish .git/refs/heads/master doesn't exist");
+        return false;
+    }
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " checkout master");
+    p.waitFor();
+
+    file = new File(basedir, "pom.xml");
+    expectedFile = new File(basedir, "expected-production-pom.xml");
+
+    actual = FileUtils.fileRead(file, "UTF-8");
+    expected = FileUtils.fileRead(expectedFile, "UTF-8");
+
+    actual = actual.replaceAll("\\r?\\n", "");
+    expected = expected.replaceAll("\\r?\\n", "");
+
+    if (!expected.equals(actual)) {
+        System.out.println("hotfix-finish: " + expected + " actual was:" + actual);
+        return false;
+    }
+
+} catch (Exception e) {
+    e.printStackTrace();
+    return false;
+}
+return true;

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
@@ -1017,15 +1017,26 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
             executeMvnCommand(TYCHO_VERSIONS_PLUGIN_SET_GOAL, prop, newVersion, "-Dtycho.mode=maven");
         } else {
+            boolean runCommand = false;
+            List<String> args = new ArrayList<>();
+            args.add("-DgenerateBackupPoms=false");
+            args.add(newVersion);
             if (!skipUpdateVersion) {
-                executeMvnCommand(VERSIONS_MAVEN_PLUGIN_SET_GOAL, grp, art, newVersion, "-DgenerateBackupPoms=false");
+                runCommand = true;
+                args.add(VERSIONS_MAVEN_PLUGIN_SET_GOAL);
+                args.add(grp);
+                args.add(art);
             }
 
             if (StringUtils.isNotBlank(versionProperty)) {
+                runCommand = true;
                 getLog().info("Updating property '" + versionProperty + "' to '" + version + "'.");
 
-                executeMvnCommand(VERSIONS_MAVEN_PLUGIN_SET_PROPERTY_GOAL, newVersion, "-Dproperty=" + versionProperty,
-                        "-DgenerateBackupPoms=false");
+                args.add(VERSIONS_MAVEN_PLUGIN_SET_PROPERTY_GOAL);
+                args.add("-Dproperty=" + versionProperty);
+            }
+            if (runCommand) {
+                executeMvnCommand(args.toArray(new String[0]));
             }
         }
     }


### PR DESCRIPTION
If versions:set and versions:set-property are launched in separate maven commands, versions:set-property can fail as poms are in an inconsistent state.

Attached test case shows a practical use-case where a property is used in dependencyManagement declaration in a multi-module project.

If project is not installed, versions:set-property 1.0.1-SNAPSHOT -> 1.0.1 fails as maven tries to resolve dependency 1.0.1-SNAPSHOT in a project already versionned in 1.0.1.

This PR builds a unique maven command, adding conditionally versions:set and versions:set-property parameters.
