### PR TITLE
Reduce maven-compiler-plugin config by using user properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,8 +63,13 @@
     </distributionManagement>
 
     <properties>
-        <java.version>1.7</java.version>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.custom.encoding>UTF-8</project.custom.encoding>
+        <project.custom.java.version>1.7</project.custom.java.version>
+        <maven.compiler.source>${project.custom.java.version}</maven.compiler.source>
+        <maven.compiler.target>${project.custom.java.version}</maven.compiler.target>
+        <project.build.outputEncoding>${project.custom.encoding}</project.build.outputEncoding>
+        <project.build.sourceEncoding>${project.custom.encoding}</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>${project.custom.encoding}</project.reporting.outputEncoding>
         <maven-plugin-plugin.version>3.6.0</maven-plugin-plugin.version>
     </properties>
 
@@ -100,11 +105,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
-                <configuration>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
-                    <encoding>${project.build.sourceEncoding}</encoding>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Reduce the verbose config required by maven/xml and use the user properties.
My other PR's are based upon this so if merged those changes would disappear.