### PR TITLE
Implementing command-line overrides for configuration

### DIFF
--- a/src/it/release-start-4-it/expected-pom.xml
+++ b/src/it/release-start-4-it/expected-pom.xml
@@ -1,0 +1,7 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.amashchenko.maven.plugin</groupId>
+    <artifactId>gitflow-maven-test</artifactId>
+    <packaging>pom</packaging>
+    <version>0.0.3</version>
+</project>

--- a/src/it/release-start-4-it/gitignorefile
+++ b/src/it/release-start-4-it/gitignorefile
@@ -1,0 +1,5 @@
+build.log
+expected-pom.xml
+invoker.properties
+init.bsh
+verify.bsh

--- a/src/it/release-start-4-it/init.bsh
+++ b/src/it/release-start-4-it/init.bsh
@@ -1,0 +1,25 @@
+try {
+    new File(basedir, "gitignorefile").renameTo(new File(basedir, ".gitignore"));
+
+    Process p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " init");
+    p.waitFor();
+
+    Process p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " config user.email 'a@a.aa'");
+    p.waitFor();
+    Process p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " config user.name 'a'");
+    p.waitFor();
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " add .");
+    p.waitFor();
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " commit -m init");
+    p.waitFor();
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " checkout -b develop");
+    p.waitFor();
+
+} catch (Exception e) {
+    e.printStackTrace();
+    return false;
+}
+return true;

--- a/src/it/release-start-4-it/invoker.properties
+++ b/src/it/release-start-4-it/invoker.properties
@@ -1,3 +1,3 @@
-invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:release-start -B -DgitFlowConfig.releaseBranchPrefix=different/
+invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:release-start -B -DgitFlowConfig=releaseBranchPrefix=different/
 
 invoker.description=Non-interactive release-start with gitFlowConfig.releaseBranchPrefix parameter.

--- a/src/it/release-start-4-it/invoker.properties
+++ b/src/it/release-start-4-it/invoker.properties
@@ -1,0 +1,3 @@
+invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:release-start -B -DgitFlowConfig.releaseBranchPrefix=different/
+
+invoker.description=Non-interactive release-start with gitFlowConfig.releaseBranchPrefix parameter.

--- a/src/it/release-start-4-it/pom.xml
+++ b/src/it/release-start-4-it/pom.xml
@@ -1,0 +1,7 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.amashchenko.maven.plugin</groupId>
+    <artifactId>gitflow-maven-test</artifactId>
+    <packaging>pom</packaging>
+    <version>0.0.3-SNAPSHOT</version>
+</project>

--- a/src/it/release-start-4-it/verify.bsh
+++ b/src/it/release-start-4-it/verify.bsh
@@ -1,0 +1,27 @@
+import org.codehaus.plexus.util.FileUtils;
+
+try {
+    File gitRef = new File(basedir, ".git/refs/heads/different/0.0.3");
+    if (!gitRef.exists()) {
+        System.out.println("release-start .git/refs/heads/different/0.0.3 doesn't exist");
+        return false;
+    }
+
+    File file = new File(basedir, "pom.xml");
+    File expectedFile = new File(basedir, "expected-pom.xml");
+
+    String actual = FileUtils.fileRead(file, "UTF-8");
+    String expected = FileUtils.fileRead(expectedFile, "UTF-8");
+
+    actual = actual.replaceAll("\\r?\\n", "");
+    expected = expected.replaceAll("\\r?\\n", "");
+
+    if (!expected.equals(actual)) {
+        System.out.println("release-start expected: " + expected + " actual was:" + actual);
+        return false;
+    }
+} catch (Exception e) {
+    e.printStackTrace();
+    return false;
+}
+return true;

--- a/src/it/release-start-5-it/expected-pom.xml
+++ b/src/it/release-start-5-it/expected-pom.xml
@@ -1,0 +1,21 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.amashchenko.maven.plugin</groupId>
+    <artifactId>gitflow-maven-test</artifactId>
+    <packaging>pom</packaging>
+    <version>0.0.3</version>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.amashchenko.maven.plugin</groupId>
+                <artifactId>gitflow-maven-plugin</artifactId>
+                <configuration>
+                    <gitFlowConfig>
+                        <productionBranch>master</productionBranch>
+                    </gitFlowConfig>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/release-start-5-it/gitignorefile
+++ b/src/it/release-start-5-it/gitignorefile
@@ -1,0 +1,5 @@
+build.log
+expected-pom.xml
+invoker.properties
+init.bsh
+verify.bsh

--- a/src/it/release-start-5-it/init.bsh
+++ b/src/it/release-start-5-it/init.bsh
@@ -1,0 +1,25 @@
+try {
+    new File(basedir, "gitignorefile").renameTo(new File(basedir, ".gitignore"));
+
+    Process p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " init");
+    p.waitFor();
+
+    Process p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " config user.email 'a@a.aa'");
+    p.waitFor();
+    Process p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " config user.name 'a'");
+    p.waitFor();
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " add .");
+    p.waitFor();
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " commit -m init");
+    p.waitFor();
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " checkout -b develop");
+    p.waitFor();
+
+} catch (Exception e) {
+    e.printStackTrace();
+    return false;
+}
+return true;

--- a/src/it/release-start-5-it/invoker.properties
+++ b/src/it/release-start-5-it/invoker.properties
@@ -1,0 +1,3 @@
+invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:release-start -B -DgitFlowConfig=releaseBranchPrefix=different/
+
+invoker.description=Non-interactive release-start with gitFlowConfig=releaseBranchPrefix parameter.

--- a/src/it/release-start-5-it/pom.xml
+++ b/src/it/release-start-5-it/pom.xml
@@ -1,0 +1,21 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.amashchenko.maven.plugin</groupId>
+    <artifactId>gitflow-maven-test</artifactId>
+    <packaging>pom</packaging>
+    <version>0.0.3-SNAPSHOT</version>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.amashchenko.maven.plugin</groupId>
+                <artifactId>gitflow-maven-plugin</artifactId>
+                <configuration>
+                    <gitFlowConfig>
+                        <productionBranch>master</productionBranch>
+                    </gitFlowConfig>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/release-start-5-it/verify.bsh
+++ b/src/it/release-start-5-it/verify.bsh
@@ -1,0 +1,27 @@
+import org.codehaus.plexus.util.FileUtils;
+
+try {
+    File gitRef = new File(basedir, ".git/refs/heads/different/0.0.3");
+    if (gitRef.exists()) {
+        System.out.println("release-start .git/refs/heads/different/0.0.3 wasn't supposed to exist");
+        return false;
+    }
+
+    File file = new File(basedir, "pom.xml");
+    File expectedFile = new File(basedir, "expected-pom.xml");
+
+    String actual = FileUtils.fileRead(file, "UTF-8");
+    String expected = FileUtils.fileRead(expectedFile, "UTF-8");
+
+    actual = actual.replaceAll("\\r?\\n", "");
+    expected = expected.replaceAll("\\r?\\n", "");
+
+    if (!expected.equals(actual)) {
+        System.out.println("release-start expected: " + expected + " actual was:" + actual);
+        return false;
+    }
+} catch (Exception e) {
+    e.printStackTrace();
+    return false;
+}
+return true;

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/CommandLineSettable.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/CommandLineSettable.java
@@ -1,0 +1,18 @@
+package com.amashchenko.maven.plugin.gitflow;
+
+import com.google.common.base.Splitter;
+import java.beans.IntrospectionException;
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Map;
+import java.util.Map.Entry;
+
+public class CommandLineSettable {
+
+    public void set(String cliConfig) throws IntrospectionException, InvocationTargetException, IllegalAccessException {
+        Map<String, String> values = Splitter.on(",").withKeyValueSeparator("=").split(cliConfig);
+        for (Entry<String, String> e : values.entrySet()) {
+            new PropertyDescriptor(e.getKey(), this.getClass()).getWriteMethod().invoke(this, e.getValue());
+        }
+    }
+}

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/CommandLineSettable.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/CommandLineSettable.java
@@ -6,9 +6,18 @@ import java.beans.PropertyDescriptor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
 import java.util.Map.Entry;
+import org.codehaus.plexus.configuration.PlexusConfiguration;
 
-public class CommandLineSettable {
+public abstract class CommandLineSettable {
 
+    /**
+     * Called by {@link org.eclipse.sisu.plexus.CompositeBeanHelper#setDefault(Object, Object, PlexusConfiguration)} during initialization
+     *
+     * @param cliConfig
+     * @throws IntrospectionException
+     * @throws InvocationTargetException
+     * @throws IllegalAccessException
+     */
     public void set(String cliConfig) throws IntrospectionException, InvocationTargetException, IllegalAccessException {
         Map<String, String> values = Splitter.on(",").withKeyValueSeparator("=").split(cliConfig);
         for (Entry<String, String> e : values.entrySet()) {

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/CommitMessages.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/CommitMessages.java
@@ -20,6 +20,9 @@ package com.amashchenko.maven.plugin.gitflow;
  *
  */
 public class CommitMessages {
+
+    private static final String PROPERTY_PREFIX = "commitMessages.";
+
     private String featureStartMessage;
     private String featureFinishMessage;
 
@@ -93,7 +96,7 @@ public class CommitMessages {
      * @return the featureStartMessage
      */
     public String getFeatureStartMessage() {
-        return featureStartMessage;
+        return System.getProperty(PROPERTY_PREFIX + "featureStartMessage", featureStartMessage);
     }
 
     /**
@@ -108,7 +111,7 @@ public class CommitMessages {
      * @return the featureFinishMessage
      */
     public String getFeatureFinishMessage() {
-        return featureFinishMessage;
+        return System.getProperty(PROPERTY_PREFIX + "featureFinishMessage", featureFinishMessage);
     }
 
     /**
@@ -123,7 +126,7 @@ public class CommitMessages {
      * @return the hotfixStartMessage
      */
     public String getHotfixStartMessage() {
-        return hotfixStartMessage;
+        return System.getProperty(PROPERTY_PREFIX + "hotfixStartMessage", hotfixStartMessage);
     }
 
     /**
@@ -138,7 +141,7 @@ public class CommitMessages {
      * @return the hotfixFinishMessage
      */
     public String getHotfixFinishMessage() {
-        return hotfixFinishMessage;
+        return System.getProperty(PROPERTY_PREFIX + "hotfixFinishMessage", hotfixFinishMessage);
     }
 
     /**
@@ -150,7 +153,7 @@ public class CommitMessages {
     }
 
     public String getHotfixVersionUpdateMessage() {
-        return hotfixVersionUpdateMessage;
+        return System.getProperty(PROPERTY_PREFIX + "hotfixVersionUpdateMessage", hotfixVersionUpdateMessage);
     }
 
     public void setHotfixVersionUpdateMessage(String hotfixVersionUpdateMessage) {
@@ -161,7 +164,7 @@ public class CommitMessages {
      * @return the releaseStartMessage
      */
     public String getReleaseStartMessage() {
-        return releaseStartMessage;
+        return System.getProperty(PROPERTY_PREFIX + "releaseStartMessage", releaseStartMessage);
     }
 
     /**
@@ -176,7 +179,7 @@ public class CommitMessages {
      * @return the releaseFinishMessage
      */
     public String getReleaseFinishMessage() {
-        return releaseFinishMessage;
+        return System.getProperty(PROPERTY_PREFIX + "releaseFinishMessage", releaseFinishMessage);
     }
 
     /**
@@ -188,7 +191,7 @@ public class CommitMessages {
     }
 
     public String getReleaseVersionUpdateMessage() {
-        return releaseVersionUpdateMessage;
+        return System.getProperty(PROPERTY_PREFIX + "releaseVersionUpdateMessage", releaseVersionUpdateMessage);
     }
 
     public void setReleaseVersionUpdateMessage(String releaseVersionUpdateMessage) {
@@ -199,7 +202,7 @@ public class CommitMessages {
      * @return the releaseFinishMergeMessage
      */
     public String getReleaseFinishMergeMessage() {
-        return releaseFinishMergeMessage;
+        return System.getProperty(PROPERTY_PREFIX + "releaseFinishMergeMessage", releaseFinishMergeMessage);
     }
 
     /**
@@ -214,7 +217,7 @@ public class CommitMessages {
      * @return the releaseFinishDevMergeMessage
      */
     public String getReleaseFinishDevMergeMessage() {
-        return releaseFinishDevMergeMessage;
+        return System.getProperty(PROPERTY_PREFIX + "releaseFinishDevMergeMessage", releaseFinishDevMergeMessage);
     }
 
     /**
@@ -229,7 +232,7 @@ public class CommitMessages {
      * @return the tagHotfixMessage
      */
     public String getTagHotfixMessage() {
-        return tagHotfixMessage;
+        return System.getProperty(PROPERTY_PREFIX + "tagHotfixMessage", tagHotfixMessage);
     }
 
     /**
@@ -244,7 +247,7 @@ public class CommitMessages {
      * @return the tagReleaseMessage
      */
     public String getTagReleaseMessage() {
-        return tagReleaseMessage;
+        return System.getProperty(PROPERTY_PREFIX + "tagReleaseMessage", tagReleaseMessage);
     }
 
     /**
@@ -259,7 +262,7 @@ public class CommitMessages {
      * @return the updateDevToAvoidConflictsMessage
      */
     public String getUpdateDevToAvoidConflictsMessage() {
-        return updateDevToAvoidConflictsMessage;
+        return System.getProperty(PROPERTY_PREFIX + "updateDevToAvoidConflictsMessage", updateDevToAvoidConflictsMessage);
     }
 
     /**
@@ -274,7 +277,7 @@ public class CommitMessages {
      * @return the updateDevBackPreMergeStateMessage
      */
     public String getUpdateDevBackPreMergeStateMessage() {
-        return updateDevBackPreMergeStateMessage;
+        return System.getProperty(PROPERTY_PREFIX + "updateDevBackPreMergeStateMessage", updateDevBackPreMergeStateMessage);
     }
 
     /**
@@ -289,7 +292,7 @@ public class CommitMessages {
      * @return the updateReleaseToAvoidConflictsMessage
      */
     public String getUpdateReleaseToAvoidConflictsMessage() {
-        return updateReleaseToAvoidConflictsMessage;
+        return System.getProperty(PROPERTY_PREFIX + "updateReleaseToAvoidConflictsMessage", updateReleaseToAvoidConflictsMessage);
     }
 
     /**
@@ -303,7 +306,7 @@ public class CommitMessages {
      * @return the updateReleaseBackPreMergeStateMessage
      */
     public String getUpdateReleaseBackPreMergeStateMessage() {
-        return updateReleaseBackPreMergeStateMessage;
+        return System.getProperty(PROPERTY_PREFIX + "updateReleaseBackPreMergeStateMessage", updateReleaseBackPreMergeStateMessage);
     }
 
     /**
@@ -317,7 +320,7 @@ public class CommitMessages {
      * @return the hotfixFinishMergeMessage
      */
     public String getHotfixFinishMergeMessage() {
-        return hotfixFinishMergeMessage;
+        return System.getProperty(PROPERTY_PREFIX + "hotfixFinishMergeMessage", hotfixFinishMergeMessage);
     }
 
     /**
@@ -332,7 +335,7 @@ public class CommitMessages {
      * @return the hotfixFinishDevMergeMessage
      */
     public String getHotfixFinishDevMergeMessage() {
-        return hotfixFinishDevMergeMessage;
+        return System.getProperty(PROPERTY_PREFIX + "hotfixFinishDevMergeMessage", hotfixFinishDevMergeMessage);
     }
 
     /**
@@ -347,7 +350,7 @@ public class CommitMessages {
      * @return the hotfixFinishReleaseMergeMessage
      */
     public String getHotfixFinishReleaseMergeMessage() {
-        return hotfixFinishReleaseMergeMessage;
+        return System.getProperty(PROPERTY_PREFIX + "hotfixFinishReleaseMergeMessage", hotfixFinishReleaseMergeMessage);
     }
 
     /**
@@ -362,7 +365,7 @@ public class CommitMessages {
      * @return the hotfixFinishSupportMergeMessage
      */
     public String getHotfixFinishSupportMergeMessage() {
-        return hotfixFinishSupportMergeMessage;
+        return System.getProperty(PROPERTY_PREFIX + "hotfixFinishSupportMergeMessage", hotfixFinishSupportMergeMessage);
     }
 
     /**
@@ -377,7 +380,7 @@ public class CommitMessages {
      * @return the featureFinishDevMergeMessage
      */
     public String getFeatureFinishDevMergeMessage() {
-        return featureFinishDevMergeMessage;
+        return System.getProperty(PROPERTY_PREFIX + "featureFinishDevMergeMessage", featureFinishDevMergeMessage);
     }
 
     /**
@@ -392,7 +395,7 @@ public class CommitMessages {
      * @return the updateFeatureBackMessage
      */
     public String getUpdateFeatureBackMessage() {
-        return updateFeatureBackMessage;
+        return System.getProperty(PROPERTY_PREFIX + "updateFeatureBackMessage", updateFeatureBackMessage);
     }
 
     /**
@@ -407,7 +410,7 @@ public class CommitMessages {
      * @return the featureFinishIncrementVersionMessage
      */
     public String getFeatureFinishIncrementVersionMessage() {
-        return featureFinishIncrementVersionMessage;
+        return System.getProperty(PROPERTY_PREFIX + "featureFinishIncrementVersionMessage", featureFinishIncrementVersionMessage);
     }
 
     /**
@@ -422,7 +425,7 @@ public class CommitMessages {
      * @return the supportStartMessage
      */
     public String getSupportStartMessage() {
-        return supportStartMessage;
+        return System.getProperty(PROPERTY_PREFIX + "supportStartMessage", supportStartMessage);
     }
 
     /**

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/CommitMessages.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/CommitMessages.java
@@ -15,14 +15,20 @@
  */
 package com.amashchenko.maven.plugin.gitflow;
 
+import com.google.common.base.Splitter;
+import java.beans.IntrospectionException;
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Map;
+import java.util.Map.Entry;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
 /**
  * Git commit messages.
  *
  */
 public class CommitMessages {
-
-    private static final String PROPERTY_PREFIX = "commitMessages.";
-
     private String featureStartMessage;
     private String featureFinishMessage;
 
@@ -92,11 +98,18 @@ public class CommitMessages {
         supportStartMessage = "Update versions for support branch";
     }
 
+    public void set(String commitMessages) throws IntrospectionException, InvocationTargetException, IllegalAccessException {
+        Map<String, String> values = Splitter.on(",").withKeyValueSeparator("=").split(commitMessages);
+        for(Entry<String, String> e : values.entrySet()) {
+            new PropertyDescriptor(e.getKey(), this.getClass()).getWriteMethod().invoke(this, e.getValue());
+        }
+    }
+
     /**
      * @return the featureStartMessage
      */
     public String getFeatureStartMessage() {
-        return System.getProperty(PROPERTY_PREFIX + "featureStartMessage", featureStartMessage);
+        return featureStartMessage;
     }
 
     /**
@@ -111,7 +124,7 @@ public class CommitMessages {
      * @return the featureFinishMessage
      */
     public String getFeatureFinishMessage() {
-        return System.getProperty(PROPERTY_PREFIX + "featureFinishMessage", featureFinishMessage);
+        return featureFinishMessage;
     }
 
     /**
@@ -126,7 +139,7 @@ public class CommitMessages {
      * @return the hotfixStartMessage
      */
     public String getHotfixStartMessage() {
-        return System.getProperty(PROPERTY_PREFIX + "hotfixStartMessage", hotfixStartMessage);
+        return hotfixStartMessage;
     }
 
     /**
@@ -141,7 +154,7 @@ public class CommitMessages {
      * @return the hotfixFinishMessage
      */
     public String getHotfixFinishMessage() {
-        return System.getProperty(PROPERTY_PREFIX + "hotfixFinishMessage", hotfixFinishMessage);
+        return hotfixFinishMessage;
     }
 
     /**
@@ -153,7 +166,7 @@ public class CommitMessages {
     }
 
     public String getHotfixVersionUpdateMessage() {
-        return System.getProperty(PROPERTY_PREFIX + "hotfixVersionUpdateMessage", hotfixVersionUpdateMessage);
+        return hotfixVersionUpdateMessage;
     }
 
     public void setHotfixVersionUpdateMessage(String hotfixVersionUpdateMessage) {
@@ -164,7 +177,7 @@ public class CommitMessages {
      * @return the releaseStartMessage
      */
     public String getReleaseStartMessage() {
-        return System.getProperty(PROPERTY_PREFIX + "releaseStartMessage", releaseStartMessage);
+        return releaseStartMessage;
     }
 
     /**
@@ -179,7 +192,7 @@ public class CommitMessages {
      * @return the releaseFinishMessage
      */
     public String getReleaseFinishMessage() {
-        return System.getProperty(PROPERTY_PREFIX + "releaseFinishMessage", releaseFinishMessage);
+        return releaseFinishMessage;
     }
 
     /**
@@ -191,7 +204,7 @@ public class CommitMessages {
     }
 
     public String getReleaseVersionUpdateMessage() {
-        return System.getProperty(PROPERTY_PREFIX + "releaseVersionUpdateMessage", releaseVersionUpdateMessage);
+        return releaseVersionUpdateMessage;
     }
 
     public void setReleaseVersionUpdateMessage(String releaseVersionUpdateMessage) {
@@ -202,7 +215,7 @@ public class CommitMessages {
      * @return the releaseFinishMergeMessage
      */
     public String getReleaseFinishMergeMessage() {
-        return System.getProperty(PROPERTY_PREFIX + "releaseFinishMergeMessage", releaseFinishMergeMessage);
+        return releaseFinishMergeMessage;
     }
 
     /**
@@ -217,7 +230,7 @@ public class CommitMessages {
      * @return the releaseFinishDevMergeMessage
      */
     public String getReleaseFinishDevMergeMessage() {
-        return System.getProperty(PROPERTY_PREFIX + "releaseFinishDevMergeMessage", releaseFinishDevMergeMessage);
+        return releaseFinishDevMergeMessage;
     }
 
     /**
@@ -232,7 +245,7 @@ public class CommitMessages {
      * @return the tagHotfixMessage
      */
     public String getTagHotfixMessage() {
-        return System.getProperty(PROPERTY_PREFIX + "tagHotfixMessage", tagHotfixMessage);
+        return tagHotfixMessage;
     }
 
     /**
@@ -247,7 +260,7 @@ public class CommitMessages {
      * @return the tagReleaseMessage
      */
     public String getTagReleaseMessage() {
-        return System.getProperty(PROPERTY_PREFIX + "tagReleaseMessage", tagReleaseMessage);
+        return tagReleaseMessage;
     }
 
     /**
@@ -262,7 +275,7 @@ public class CommitMessages {
      * @return the updateDevToAvoidConflictsMessage
      */
     public String getUpdateDevToAvoidConflictsMessage() {
-        return System.getProperty(PROPERTY_PREFIX + "updateDevToAvoidConflictsMessage", updateDevToAvoidConflictsMessage);
+        return updateDevToAvoidConflictsMessage;
     }
 
     /**
@@ -277,7 +290,7 @@ public class CommitMessages {
      * @return the updateDevBackPreMergeStateMessage
      */
     public String getUpdateDevBackPreMergeStateMessage() {
-        return System.getProperty(PROPERTY_PREFIX + "updateDevBackPreMergeStateMessage", updateDevBackPreMergeStateMessage);
+        return updateDevBackPreMergeStateMessage;
     }
 
     /**
@@ -292,7 +305,7 @@ public class CommitMessages {
      * @return the updateReleaseToAvoidConflictsMessage
      */
     public String getUpdateReleaseToAvoidConflictsMessage() {
-        return System.getProperty(PROPERTY_PREFIX + "updateReleaseToAvoidConflictsMessage", updateReleaseToAvoidConflictsMessage);
+        return updateReleaseToAvoidConflictsMessage;
     }
 
     /**
@@ -306,7 +319,7 @@ public class CommitMessages {
      * @return the updateReleaseBackPreMergeStateMessage
      */
     public String getUpdateReleaseBackPreMergeStateMessage() {
-        return System.getProperty(PROPERTY_PREFIX + "updateReleaseBackPreMergeStateMessage", updateReleaseBackPreMergeStateMessage);
+        return updateReleaseBackPreMergeStateMessage;
     }
 
     /**
@@ -320,7 +333,7 @@ public class CommitMessages {
      * @return the hotfixFinishMergeMessage
      */
     public String getHotfixFinishMergeMessage() {
-        return System.getProperty(PROPERTY_PREFIX + "hotfixFinishMergeMessage", hotfixFinishMergeMessage);
+        return hotfixFinishMergeMessage;
     }
 
     /**
@@ -335,7 +348,7 @@ public class CommitMessages {
      * @return the hotfixFinishDevMergeMessage
      */
     public String getHotfixFinishDevMergeMessage() {
-        return System.getProperty(PROPERTY_PREFIX + "hotfixFinishDevMergeMessage", hotfixFinishDevMergeMessage);
+        return hotfixFinishDevMergeMessage;
     }
 
     /**
@@ -350,7 +363,7 @@ public class CommitMessages {
      * @return the hotfixFinishReleaseMergeMessage
      */
     public String getHotfixFinishReleaseMergeMessage() {
-        return System.getProperty(PROPERTY_PREFIX + "hotfixFinishReleaseMergeMessage", hotfixFinishReleaseMergeMessage);
+        return hotfixFinishReleaseMergeMessage;
     }
 
     /**
@@ -365,7 +378,7 @@ public class CommitMessages {
      * @return the hotfixFinishSupportMergeMessage
      */
     public String getHotfixFinishSupportMergeMessage() {
-        return System.getProperty(PROPERTY_PREFIX + "hotfixFinishSupportMergeMessage", hotfixFinishSupportMergeMessage);
+        return hotfixFinishSupportMergeMessage;
     }
 
     /**
@@ -380,7 +393,7 @@ public class CommitMessages {
      * @return the featureFinishDevMergeMessage
      */
     public String getFeatureFinishDevMergeMessage() {
-        return System.getProperty(PROPERTY_PREFIX + "featureFinishDevMergeMessage", featureFinishDevMergeMessage);
+        return featureFinishDevMergeMessage;
     }
 
     /**
@@ -395,7 +408,7 @@ public class CommitMessages {
      * @return the updateFeatureBackMessage
      */
     public String getUpdateFeatureBackMessage() {
-        return System.getProperty(PROPERTY_PREFIX + "updateFeatureBackMessage", updateFeatureBackMessage);
+        return updateFeatureBackMessage;
     }
 
     /**
@@ -410,7 +423,7 @@ public class CommitMessages {
      * @return the featureFinishIncrementVersionMessage
      */
     public String getFeatureFinishIncrementVersionMessage() {
-        return System.getProperty(PROPERTY_PREFIX + "featureFinishIncrementVersionMessage", featureFinishIncrementVersionMessage);
+        return featureFinishIncrementVersionMessage;
     }
 
     /**
@@ -425,7 +438,7 @@ public class CommitMessages {
      * @return the supportStartMessage
      */
     public String getSupportStartMessage() {
-        return System.getProperty(PROPERTY_PREFIX + "supportStartMessage", supportStartMessage);
+        return supportStartMessage;
     }
 
     /**

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/CommitMessages.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/CommitMessages.java
@@ -15,20 +15,11 @@
  */
 package com.amashchenko.maven.plugin.gitflow;
 
-import com.google.common.base.Splitter;
-import java.beans.IntrospectionException;
-import java.beans.PropertyDescriptor;
-import java.lang.reflect.InvocationTargetException;
-import java.util.Map;
-import java.util.Map.Entry;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
-
 /**
  * Git commit messages.
  *
  */
-public class CommitMessages {
+public class CommitMessages extends CommandLineSettable {
     private String featureStartMessage;
     private String featureFinishMessage;
 
@@ -96,13 +87,6 @@ public class CommitMessages {
         featureFinishIncrementVersionMessage = "Increment feature version";
 
         supportStartMessage = "Update versions for support branch";
-    }
-
-    public void set(String commitMessages) throws IntrospectionException, InvocationTargetException, IllegalAccessException {
-        Map<String, String> values = Splitter.on(",").withKeyValueSeparator("=").split(commitMessages);
-        for(Entry<String, String> e : values.entrySet()) {
-            new PropertyDescriptor(e.getKey(), this.getClass()).getWriteMethod().invoke(this, e.getValue());
-        }
     }
 
     /**

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowConfig.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowConfig.java
@@ -15,18 +15,11 @@
  */
 package com.amashchenko.maven.plugin.gitflow;
 
-import com.google.common.base.Splitter;
-import java.beans.IntrospectionException;
-import java.beans.PropertyDescriptor;
-import java.lang.reflect.InvocationTargetException;
-import java.util.Map;
-import java.util.Map.Entry;
-
 /**
  * Git flow configuration.
  *
  */
-public class GitFlowConfig {
+public class GitFlowConfig extends CommandLineSettable {
     /** Name of the production branch. */
     private String productionBranch;
     /** Name of the development branch. */
@@ -56,13 +49,6 @@ public class GitFlowConfig {
         this.supportBranchPrefix = "support/";
         this.versionTagPrefix = "";
         this.origin = "origin";
-    }
-
-    public void set(String gitFlowConfig) throws IntrospectionException, InvocationTargetException, IllegalAccessException {
-        Map<String, String> values = Splitter.on(",").withKeyValueSeparator("=").split(gitFlowConfig);
-        for(Entry<String, String> e : values.entrySet()) {
-            new PropertyDescriptor(e.getKey(), this.getClass()).getWriteMethod().invoke(this, e.getValue());
-        }
     }
 
     /**

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowConfig.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowConfig.java
@@ -17,9 +17,12 @@ package com.amashchenko.maven.plugin.gitflow;
 
 /**
  * Git flow configuration.
- * 
+ *
  */
 public class GitFlowConfig {
+
+    private static final String PROPERTY_PREFIX = "gitFlowConfig.";
+
     /** Name of the production branch. */
     private String productionBranch;
     /** Name of the development branch. */
@@ -55,7 +58,7 @@ public class GitFlowConfig {
      * @return the productionBranch
      */
     public String getProductionBranch() {
-        return productionBranch;
+        return System.getProperty(PROPERTY_PREFIX + "productionBranch", productionBranch);
     }
 
     /**
@@ -70,7 +73,7 @@ public class GitFlowConfig {
      * @return the developmentBranch
      */
     public String getDevelopmentBranch() {
-        return developmentBranch;
+        return System.getProperty(PROPERTY_PREFIX + "developmentBranch", developmentBranch);
     }
 
     /**
@@ -85,7 +88,7 @@ public class GitFlowConfig {
      * @return the featureBranchPrefix
      */
     public String getFeatureBranchPrefix() {
-        return featureBranchPrefix;
+        return System.getProperty(PROPERTY_PREFIX + "featureBranchPrefix", featureBranchPrefix);
     }
 
     /**
@@ -100,7 +103,7 @@ public class GitFlowConfig {
      * @return the releaseBranchPrefix
      */
     public String getReleaseBranchPrefix() {
-        return releaseBranchPrefix;
+        return System.getProperty(PROPERTY_PREFIX + "releaseBranchPrefix", releaseBranchPrefix);
     }
 
     /**
@@ -115,7 +118,7 @@ public class GitFlowConfig {
      * @return the hotfixBranchPrefix
      */
     public String getHotfixBranchPrefix() {
-        return hotfixBranchPrefix;
+        return System.getProperty(PROPERTY_PREFIX + "hotfixBranchPrefix", hotfixBranchPrefix);
     }
 
     /**
@@ -130,7 +133,7 @@ public class GitFlowConfig {
      * @return the supportBranchPrefix
      */
     public String getSupportBranchPrefix() {
-        return supportBranchPrefix;
+        return System.getProperty(PROPERTY_PREFIX + "supportBranchPrefix", supportBranchPrefix);
     }
 
     /**
@@ -145,7 +148,7 @@ public class GitFlowConfig {
      * @return the versionTagPrefix
      */
     public String getVersionTagPrefix() {
-        return versionTagPrefix;
+        return System.getProperty(PROPERTY_PREFIX + "versionTagPrefix", versionTagPrefix);
     }
 
     /**
@@ -160,7 +163,7 @@ public class GitFlowConfig {
      * @return the origin
      */
     public String getOrigin() {
-        return origin;
+        return System.getProperty(PROPERTY_PREFIX + "origin", origin);
     }
 
     /**

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowConfig.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowConfig.java
@@ -15,14 +15,18 @@
  */
 package com.amashchenko.maven.plugin.gitflow;
 
+import com.google.common.base.Splitter;
+import java.beans.IntrospectionException;
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Map;
+import java.util.Map.Entry;
+
 /**
  * Git flow configuration.
  *
  */
 public class GitFlowConfig {
-
-    private static final String PROPERTY_PREFIX = "gitFlowConfig.";
-
     /** Name of the production branch. */
     private String productionBranch;
     /** Name of the development branch. */
@@ -54,11 +58,18 @@ public class GitFlowConfig {
         this.origin = "origin";
     }
 
+    public void set(String gitFlowConfig) throws IntrospectionException, InvocationTargetException, IllegalAccessException {
+        Map<String, String> values = Splitter.on(",").withKeyValueSeparator("=").split(gitFlowConfig);
+        for(Entry<String, String> e : values.entrySet()) {
+            new PropertyDescriptor(e.getKey(), this.getClass()).getWriteMethod().invoke(this, e.getValue());
+        }
+    }
+
     /**
      * @return the productionBranch
      */
     public String getProductionBranch() {
-        return System.getProperty(PROPERTY_PREFIX + "productionBranch", productionBranch);
+        return productionBranch;
     }
 
     /**
@@ -73,7 +84,7 @@ public class GitFlowConfig {
      * @return the developmentBranch
      */
     public String getDevelopmentBranch() {
-        return System.getProperty(PROPERTY_PREFIX + "developmentBranch", developmentBranch);
+        return developmentBranch;
     }
 
     /**
@@ -88,7 +99,7 @@ public class GitFlowConfig {
      * @return the featureBranchPrefix
      */
     public String getFeatureBranchPrefix() {
-        return System.getProperty(PROPERTY_PREFIX + "featureBranchPrefix", featureBranchPrefix);
+        return featureBranchPrefix;
     }
 
     /**
@@ -103,7 +114,7 @@ public class GitFlowConfig {
      * @return the releaseBranchPrefix
      */
     public String getReleaseBranchPrefix() {
-        return System.getProperty(PROPERTY_PREFIX + "releaseBranchPrefix", releaseBranchPrefix);
+        return releaseBranchPrefix;
     }
 
     /**
@@ -118,7 +129,7 @@ public class GitFlowConfig {
      * @return the hotfixBranchPrefix
      */
     public String getHotfixBranchPrefix() {
-        return System.getProperty(PROPERTY_PREFIX + "hotfixBranchPrefix", hotfixBranchPrefix);
+        return hotfixBranchPrefix;
     }
 
     /**
@@ -133,7 +144,7 @@ public class GitFlowConfig {
      * @return the supportBranchPrefix
      */
     public String getSupportBranchPrefix() {
-        return System.getProperty(PROPERTY_PREFIX + "supportBranchPrefix", supportBranchPrefix);
+        return supportBranchPrefix;
     }
 
     /**
@@ -148,7 +159,7 @@ public class GitFlowConfig {
      * @return the versionTagPrefix
      */
     public String getVersionTagPrefix() {
-        return System.getProperty(PROPERTY_PREFIX + "versionTagPrefix", versionTagPrefix);
+        return versionTagPrefix;
     }
 
     /**
@@ -163,7 +174,7 @@ public class GitFlowConfig {
      * @return the origin
      */
     public String getOrigin() {
-        return System.getProperty(PROPERTY_PREFIX + "origin", origin);
+        return origin;
     }
 
     /**


### PR DESCRIPTION
Fix for #284 where CLI parameters in the form of `-DgitFlowConfig.developmentBranch=foobar` or `-DcommitMessages.hotfixVersionUpdateMessage=hello` override pom-specified plugin configuration.