### PR TITLE
Add space after commitMessagePrefix

### DIFF
--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
@@ -44,7 +44,7 @@ import org.codehaus.plexus.util.cli.Commandline;
 
 /**
  * Abstract git flow mojo.
- * 
+ *
  */
 public abstract class AbstractGitFlowMojo extends AbstractMojo {
     /** A full name of the versions-maven-plugin set goal. */
@@ -77,7 +77,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Git commit messages.
-     * 
+     *
      * @since 1.2.1
      */
     @Parameter(defaultValue = "${commitMessages}")
@@ -85,15 +85,15 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Whether this is Tycho build.
-     * 
+     *
      * @since 1.1.0
      */
     @Parameter(defaultValue = "false")
     protected boolean tychoBuild;
-    
+
     /**
      * Whether to call Maven install goal during the mojo execution.
-     * 
+     *
      * @since 1.0.5
      */
     @Parameter(property = "installProject", defaultValue = "false")
@@ -101,7 +101,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Whether to fetch remote branch and compare it with the local one.
-     * 
+     *
      * @since 1.3.0
      */
     @Parameter(property = "fetchRemote", defaultValue = "true")
@@ -109,7 +109,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Whether to print commands output into the console.
-     * 
+     *
      * @since 1.0.7
      */
     @Parameter(property = "verbose", defaultValue = "false")
@@ -117,7 +117,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Command line arguments to pass to the underlying Maven commands.
-     * 
+     *
      * @since 1.8.0
      */
     @Parameter(property = "argLine")
@@ -125,7 +125,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Whether to make a GPG-signed commit.
-     * 
+     *
      * @since 1.9.0
      */
     @Parameter(property = "gpgSignCommit", defaultValue = "false")
@@ -134,7 +134,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
     /**
      * Whether to set -DgroupId='*' -DartifactId='*' when calling
      * versions-maven-plugin.
-     * 
+     *
      * @since 1.10.0
      */
     @Parameter(property = "versionsForceUpdate", defaultValue = "false")
@@ -151,7 +151,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
     /**
      * Whether to skip updating version. Useful with {@link #versionProperty} to be
      * able to update <code>revision</code> property without modifying version tag.
-     * 
+     *
      * @since 1.13.0
      */
     @Parameter(property = "skipUpdateVersion")
@@ -159,7 +159,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Prefix that is applied to commit messages.
-     * 
+     *
      * @since 1.14.0
      */
     @Parameter(property = "commitMessagePrefix")
@@ -182,7 +182,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     @Component
     protected ProjectBuilder projectBuilder;
-    
+
     /** Default prompter. */
     @Component
     protected Prompter prompter;
@@ -192,7 +192,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Initializes command line executables.
-     * 
+     *
      */
     private void initExecutables() {
         if (StringUtils.isBlank(cmdMvn.getExecutable())) {
@@ -212,7 +212,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
     /**
      * Validates plugin configuration. Throws exception if configuration is not
      * valid.
-     * 
+     *
      * @param params
      *            Configuration parameters to validate.
      * @throws MojoFailureException
@@ -238,7 +238,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Gets current project version from pom.xml file.
-     * 
+     *
      * @return Current project version.
      * @throws MojoFailureException
      */
@@ -254,7 +254,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
     /**
      * Gets current project {@link #REPRODUCIBLE_BUILDS_PROPERTY} property value
      * from pom.xml file.
-     * 
+     *
      * @return Value of {@link #REPRODUCIBLE_BUILDS_PROPERTY} property.
      * @throws MojoFailureException
      */
@@ -265,7 +265,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Reloads project info from file
-     * 
+     *
      * @param project
      * @return
      * @throws MojoFailureException
@@ -281,7 +281,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Compares the production branch name with the development branch name.
-     * 
+     *
      * @return <code>true</code> if the production branch name is different from
      *         the development branch name, <code>false</code> otherwise.
      */
@@ -292,7 +292,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Checks uncommitted changes.
-     * 
+     *
      * @throws MojoFailureException
      * @throws CommandLineException
      */
@@ -338,7 +338,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Checks if branch name is acceptable.
-     * 
+     *
      * @param branchName
      *            Branch name to check.
      * @return <code>true</code> when name is valid, <code>false</code>
@@ -355,7 +355,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git commands to check for uncommitted changes.
-     * 
+     *
      * @return <code>true</code> when there are uncommitted changes,
      *         <code>false</code> otherwise.
      * @throws CommandLineException
@@ -397,7 +397,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git config commands to set Git Flow configuration.
-     * 
+     *
      * @throws MojoFailureException
      * @throws CommandLineException
      */
@@ -424,7 +424,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git config command.
-     * 
+     *
      * @param name
      *            Option name.
      * @param value
@@ -444,7 +444,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git for-each-ref with <code>refname:short</code> format.
-     * 
+     *
      * @param branchName
      *            Branch name to find.
      * @param firstMatch
@@ -460,7 +460,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git for-each-ref with <code>refname:short</code> format.
-     * 
+     *
      * @param refs
      *            Refs to search.
      * @param branchName
@@ -530,7 +530,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Removes double quotes from the string.
-     * 
+     *
      * @param str
      *            String to remove quotes from.
      * @return String without quotes.
@@ -544,7 +544,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Gets the current branch name.
-     * 
+     *
      * @return Current branch name.
      * @throws MojoFailureException
      * @throws CommandLineException
@@ -643,7 +643,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Replaces properties in message.
-     * 
+     *
      * @param message
      * @param map
      *            Key is a string to replace wrapped in <code>@{...}</code>. Value
@@ -661,7 +661,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git commit -a -m.
-     * 
+     *
      * @param message
      *            Commit message.
      * @throws MojoFailureException
@@ -675,7 +675,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
     /**
      * Executes git commit -a -m, replacing <code>@{map.key}</code> with
      * <code>map.value</code>.
-     * 
+     *
      * @param message
      *            Commit message.
      * @param messageProperties
@@ -686,7 +686,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
     protected void gitCommit(String message, Map<String, String> messageProperties)
             throws MojoFailureException, CommandLineException {
         if (StringUtils.isNotBlank(commitMessagePrefix)) {
-            message = commitMessagePrefix + message;
+            message = commitMessagePrefix + " " + message;
         }
 
         message = replaceProperties(message, messageProperties);
@@ -704,7 +704,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git rebase or git merge --ff-only or git merge --no-ff or git merge.
-     * 
+     *
      * @param branchName
      *            Branch name to merge.
      * @param rebase
@@ -754,7 +754,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git merge --no-ff.
-     * 
+     *
      * @param branchName
      *            Branch name to merge.
      * @param message
@@ -772,7 +772,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git merge --squash.
-     * 
+     *
      * @param branchName
      *            Branch name to merge.
      * @throws MojoFailureException
@@ -786,7 +786,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git tag -a [-s] -m.
-     * 
+     *
      * @param tagName
      *            Name of the tag.
      * @param message
@@ -815,7 +815,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git branch -d.
-     * 
+     *
      * @param branchName
      *            Branch name to delete.
      * @throws MojoFailureException
@@ -830,7 +830,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git branch -D.
-     * 
+     *
      * @param branchName
      *            Branch name to delete.
      * @throws MojoFailureException
@@ -845,7 +845,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Fetches and checkouts from remote if local branch doesn't exist.
-     * 
+     *
      * @param branchName
      *            Branch name to check.
      * @throws MojoFailureException
@@ -867,7 +867,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git fetch and compares local branch with the remote.
-     * 
+     *
      * @param branchName
      *            Branch name to fetch and compare.
      * @throws MojoFailureException
@@ -901,7 +901,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
     /**
      * Executes git fetch and git for-each-ref with <code>refname:short</code>
      * format. Searches <code>refs/remotes/{remoteName}/</code>.
-     * 
+     *
      * @param remoteName
      *            Name of the remote.
      * @param branchName
@@ -920,7 +920,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git fetch.
-     * 
+     *
      * @return <code>true</code> if git fetch returned success exit code,
      *         <code>false</code> otherwise.
      * @throws MojoFailureException
@@ -932,7 +932,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git fetch with specific branch.
-     * 
+     *
      * @param branchName
      *            Branch name to fetch.
      * @return <code>true</code> if git fetch returned success exit code,
@@ -965,7 +965,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
     /**
      * Executes git push, optionally with the <code>--follow-tags</code>
      * argument.
-     * 
+     *
      * @param branchName
      *            Branch name to push.
      * @param pushTags
@@ -1009,7 +1009,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
     /**
      * Executes 'set' goal of versions-maven-plugin or 'set-version' of
      * tycho-versions-plugin in case it is tycho build.
-     * 
+     *
      * @param version
      *            New version to set.
      * @throws MojoFailureException
@@ -1079,7 +1079,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes mvn clean test.
-     * 
+     *
      * @throws MojoFailureException
      * @throws CommandLineException
      */
@@ -1095,7 +1095,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes mvn clean install.
-     * 
+     *
      * @throws MojoFailureException
      * @throws CommandLineException
      */
@@ -1108,7 +1108,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes Maven goals.
-     * 
+     *
      * @param goals
      *            The goals to execute.
      * @throws Exception
@@ -1121,7 +1121,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes Git command and returns output.
-     * 
+     *
      * @param args
      *            Git command line arguments.
      * @return Command output.
@@ -1135,7 +1135,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes Git command without failing on non successful exit code.
-     * 
+     *
      * @param args
      *            Git command line arguments.
      * @return Command result.
@@ -1149,7 +1149,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes Git command.
-     * 
+     *
      * @param args
      *            Git command line arguments.
      * @throws CommandLineException
@@ -1162,7 +1162,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes Maven command.
-     * 
+     *
      * @param args
      *            Maven command line arguments.
      * @throws CommandLineException
@@ -1175,7 +1175,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes command line.
-     * 
+     *
      * @param cmd
      *            Command line.
      * @param failOnError


### PR DESCRIPTION
Add a space after commitMessagePrefix to have better commit message when prefix is set. This PR is to solve issue #293