### PR TITLE
Use releaseStartMessage in releaseFinish if useSnapshotInRelease is true

### DIFF
--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowReleaseFinishMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowReleaseFinishMojo.java
@@ -257,7 +257,7 @@ public class GitFlowReleaseFinishMojo extends AbstractGitFlowMojo {
 
                 messageProperties.put("version", commitVersion);
 
-                gitCommit(commitMessages.getReleaseFinishMessage(), messageProperties);
+                gitCommit(commitMessages.getReleaseStartMessage(), messageProperties);
             }
 
             if (!skipReleaseMergeProdBranch) {


### PR DESCRIPTION
Change the message used to bump version to releaseVersion in releaseFinish step if useSnapshotInRelease is set to true.
Previously both this message, occurring in release branche before merging, and the message on develop branch after merge were the same "Update for next development version".
Now commit message for setting release version is Update versions for release as it is when release version is set during releaseStart step.