### PR TITLE
Create next development version in release branch before merge with develop

### DIFF
--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
@@ -686,7 +686,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
     protected void gitCommit(String message, Map<String, String> messageProperties)
             throws MojoFailureException, CommandLineException {
         if (StringUtils.isNotBlank(commitMessagePrefix)) {
-            message = commitMessagePrefix + message;
+            message = commitMessagePrefix + " " + message;
         }
 
         message = replaceProperties(message, messageProperties);
@@ -731,7 +731,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
         String msg = "";
         if (StringUtils.isNotBlank(message)) {
             if (StringUtils.isNotBlank(commitMessagePrefix)) {
-                message = commitMessagePrefix + message;
+                message = commitMessagePrefix + " " + message;
             }
 
             msgParam = "-m";


### PR DESCRIPTION
Hallo, we use another kind of save merge from release branch to develop. We make following steps:

1. fork release branch
2. set release version in pom and commit (as achieved using gitflow:release-start)
3. merge release branch with master branch
4. set next development version in pom and commit in release branch
5. merge release branch with development branch

Is it possible to include such scenario into gitflow:release-finish goal?
