### PR TITLE
Makes update of outputTimestamp property optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ To configure your Maven build to support reproducible builds follow [official gu
 
 If your project has `project.build.outputTimestamp` property this plugin will update its value whenever the versions are updated. 
 
+This can be disabled by setting the configuration parameter `updateOutputTimestamp` to `false`.
+
 
 # Plugin Common Parameters
 

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
@@ -180,6 +180,14 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
     @Parameter(defaultValue = "${session}", readonly = true)
     protected MavenSession mavenSession;
 
+    /**
+     * Whether to update the <code>project.build.outputTimestamp</code>> property automatically or not.
+     *
+     * @since 1.16.1
+     */
+    @Parameter(property = "updateOutputTimestamp")
+    private boolean updateOutputTimestamp = true;
+
     @Component
     protected ProjectBuilder projectBuilder;
     
@@ -1057,7 +1065,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
                 executeMvnCommand(args.toArray(new String[0]));
 
                 String timestamp = getCurrentProjectOutputTimestamp();
-                if (timestamp != null && timestamp.length() > 1) {
+                if (timestamp != null && timestamp.length() > 1 && updateOutputTimestamp) {
                     if (StringUtils.isNumeric(timestamp)) {
                         // int representing seconds since the epoch
                         timestamp = String.valueOf(System.currentTimeMillis() / 1000l);

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
@@ -181,11 +181,11 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
     protected MavenSession mavenSession;
 
     /**
-     * Whether to update the <code>project.build.outputTimestamp</code>> property automatically or not.
+     * Whether to update the <code>project.build.outputTimestamp</code> property automatically or not.
      *
      * @since 1.16.1
      */
-    @Parameter(property = "updateOutputTimestamp")
+    @Parameter(property = "updateOutputTimestamp", defaultValue = "true")
     private boolean updateOutputTimestamp = true;
 
     @Component
@@ -1064,22 +1064,24 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
             if (runCommand) {
                 executeMvnCommand(args.toArray(new String[0]));
 
-                String timestamp = getCurrentProjectOutputTimestamp();
-                if (timestamp != null && timestamp.length() > 1 && updateOutputTimestamp) {
-                    if (StringUtils.isNumeric(timestamp)) {
-                        // int representing seconds since the epoch
-                        timestamp = String.valueOf(System.currentTimeMillis() / 1000l);
-                    } else {
-                        // ISO-8601
-                        DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
-                        df.setTimeZone(TimeZone.getTimeZone("UTC"));
-                        timestamp = df.format(new Date());
+                if (updateOutputTimestamp) {
+                    String timestamp = getCurrentProjectOutputTimestamp();
+                    if (timestamp != null && timestamp.length() > 1) {
+                        if (StringUtils.isNumeric(timestamp)) {
+                            // int representing seconds since the epoch
+                            timestamp = String.valueOf(System.currentTimeMillis() / 1000l);
+                        } else {
+                            // ISO-8601
+                            DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+                            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+                            timestamp = df.format(new Date());
+                        }
+
+                        getLog().info("Updating property '" + REPRODUCIBLE_BUILDS_PROPERTY + "' to '" + timestamp + "'.");
+
+                        executeMvnCommand(VERSIONS_MAVEN_PLUGIN_SET_PROPERTY_GOAL, "-DgenerateBackupPoms=false",
+                                "-Dproperty=" + REPRODUCIBLE_BUILDS_PROPERTY, "-DnewVersion=" + timestamp);
                     }
-
-                    getLog().info("Updating property '" + REPRODUCIBLE_BUILDS_PROPERTY + "' to '" + timestamp + "'.");
-
-                    executeMvnCommand(VERSIONS_MAVEN_PLUGIN_SET_PROPERTY_GOAL, "-DgenerateBackupPoms=false",
-                            "-Dproperty=" + REPRODUCIBLE_BUILDS_PROPERTY, "-DnewVersion=" + timestamp);
                 }
             }
         }


### PR DESCRIPTION
Allow `outputTimestamp` to be set to a fix value, not the current Date. In my use-case, `project.build.outputTimestamp` is set to `${git.commit.time}` in the pom  and allows a binary reproducible build of any given tag/commit-id. Whether it is a release or not.
But using a fixed timestamp during development commits breaks (in my case) things like `last-modified` headers in http responses.