### PR TITLE
pom.xml: set the java source version to javadoc source version as well

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,6 +159,9 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <version>3.1.0</version>
+                        <configuration>
+                            <source>1.7</source>>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>


### PR DESCRIPTION
Java version is specified with 1.7 in the pom.xml. Building the project locally with a newer JDK > 8 produces errors with javadoc.
To circumvent this issue, the javadoc configuration is extended by specifying the javadoc source version to 1.7 as well.