### PR TITLE
#64 Check for SNAPSHOT dependency in parent project definition

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,7 +191,7 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-invoker-plugin</artifactId>
-                        <version>3.2.0</version>
+                        <version>3.2.2</version>
                         <configuration>
                             <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
                             <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>

--- a/src/it/release-start-it-snapshot-dependency-fail/gitignorefile
+++ b/src/it/release-start-it-snapshot-dependency-fail/gitignorefile
@@ -1,0 +1,5 @@
+build.log
+expected-pom.xml
+invoker.properties
+init.bsh
+verify.bsh

--- a/src/it/release-start-it-snapshot-dependency-fail/init.bsh
+++ b/src/it/release-start-it-snapshot-dependency-fail/init.bsh
@@ -1,0 +1,26 @@
+import org.apache.commons.io.FileUtils;
+
+try {
+    new File(basedir, "gitignorefile").renameTo(new File(basedir, ".gitignore"));
+
+    Process p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " init");
+    p.waitFor();
+
+    Process p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " config user.email 'a@a.aa'");
+    p.waitFor();
+    Process p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " config user.name 'a'");
+    p.waitFor();
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " add .");
+    p.waitFor();
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " commit -m init");
+    p.waitFor();
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " checkout -b develop");
+    p.waitFor();
+} catch (Exception e) {
+    e.printStackTrace();
+    return false;
+}
+return true;

--- a/src/it/release-start-it-snapshot-dependency-fail/invoker.properties
+++ b/src/it/release-start-it-snapshot-dependency-fail/invoker.properties
@@ -1,0 +1,5 @@
+invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:release-start -B
+
+invoker.description=Non-interactive simple release-start: Failure due to SNAPSHOT dependency
+
+invoker.buildResult=failure

--- a/src/it/release-start-it-snapshot-dependency-fail/pom.xml
+++ b/src/it/release-start-it-snapshot-dependency-fail/pom.xml
@@ -1,0 +1,17 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.amashchenko.maven.plugin</groupId>
+    <artifactId>gitflow-maven-test</artifactId>
+    <packaging>pom</packaging>
+    <version>0.0.3-SNAPSHOT</version>
+    
+    <dependencies>
+        <dependency>
+            <groupId>localhost</groupId>
+            <artifactId>dummy-api</artifactId>
+            <version>1.1-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/src/it/release-start-it-snapshot-dependency-fail/verify.groovy
+++ b/src/it/release-start-it-snapshot-dependency-fail/verify.groovy
@@ -1,0 +1,9 @@
+File file = new File( basedir, "build.log" );
+assert file.exists();
+
+String text = file.getText("utf-8");
+
+// ensure build fails due to SNAPSHOT dependencies
+assert text.contains("There is some SNAPSHOT dependencies in the project,")
+
+return true;

--- a/src/it/release-start-it-snapshot-parent-fail/dummy-parent/pom.xml
+++ b/src/it/release-start-it-snapshot-parent-fail/dummy-parent/pom.xml
@@ -1,0 +1,10 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>localhost</groupId>
+  <artifactId>dummy-parent</artifactId>
+  <version>1.1-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+</project>

--- a/src/it/release-start-it-snapshot-parent-fail/gitignorefile
+++ b/src/it/release-start-it-snapshot-parent-fail/gitignorefile
@@ -1,0 +1,5 @@
+build.log
+expected-pom.xml
+invoker.properties
+init.bsh
+verify.bsh

--- a/src/it/release-start-it-snapshot-parent-fail/init.bsh
+++ b/src/it/release-start-it-snapshot-parent-fail/init.bsh
@@ -1,0 +1,26 @@
+import org.apache.commons.io.FileUtils;
+
+try {
+    new File(basedir, "gitignorefile").renameTo(new File(basedir, ".gitignore"));
+
+    Process p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " init");
+    p.waitFor();
+
+    Process p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " config user.email 'a@a.aa'");
+    p.waitFor();
+    Process p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " config user.name 'a'");
+    p.waitFor();
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " add .");
+    p.waitFor();
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " commit -m init");
+    p.waitFor();
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " checkout -b develop");
+    p.waitFor();
+} catch (Exception e) {
+    e.printStackTrace();
+    return false;
+}
+return true;

--- a/src/it/release-start-it-snapshot-parent-fail/invoker.properties
+++ b/src/it/release-start-it-snapshot-parent-fail/invoker.properties
@@ -1,0 +1,5 @@
+invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:release-start -B
+
+invoker.description=Non-interactive simple release-start: Failure due to SNAPSHOT parent dependency
+
+invoker.buildResult=failure

--- a/src/it/release-start-it-snapshot-parent-fail/pom.xml
+++ b/src/it/release-start-it-snapshot-parent-fail/pom.xml
@@ -1,0 +1,13 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <parent>
+        <groupId>localhost</groupId>
+        <artifactId>dummy-parent</artifactId>
+        <version>1.1-SNAPSHOT</version>
+        <relativePath>dummy-parent</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.amashchenko.maven.plugin</groupId>
+    <artifactId>gitflow-maven-test</artifactId>
+    <packaging>pom</packaging>
+    <version>0.0.3-SNAPSHOT</version>
+</project>

--- a/src/it/release-start-it-snapshot-parent-fail/verify.groovy
+++ b/src/it/release-start-it-snapshot-parent-fail/verify.groovy
@@ -1,0 +1,9 @@
+File file = new File( basedir, "build.log" );
+assert file.exists();
+
+String text = file.getText("utf-8");
+
+// ensure build fails due to SNAPSHOT dependencies
+assert text.contains("There is some SNAPSHOT dependencies in the project,")
+
+return true;

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
@@ -19,9 +19,11 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.TimeZone;
 import java.util.regex.Pattern;
 
@@ -340,7 +342,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
         getLog().info("Checking for SNAPSHOT versions in dependencies.");
 
         List<String> snapshots = new ArrayList<>();
-        List<String> builtArtifacts = new ArrayList<>();
+        Set<String> builtArtifacts = new HashSet<>();
 
         List<MavenProject> projects = mavenSession.getProjects();
         for (MavenProject project : projects) {
@@ -353,6 +355,13 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
                 String id = d.getGroupId() + ":" + d.getArtifactId() + ":" + d.getVersion();
                 if (!builtArtifacts.contains(id) && ArtifactUtils.isSnapshot(d.getVersion())) {
                     snapshots.add(reloadedProject + " -> " + d);
+                }
+            }
+            MavenProject parent = reloadedProject.getParent();
+            if (parent != null) {
+                String id = parent.getGroupId() + ":" + parent.getArtifactId() + ":" + parent.getVersion();
+                if (!builtArtifacts.contains(id) && ArtifactUtils.isSnapshot(parent.getVersion())) {
+                    snapshots.add(reloadedProject + " -> " + parent);
                 }
             }
         }


### PR DESCRIPTION
add integration tests to cover SNAPSHOT dependency check

_please note_: when implementing the integration tests i realized that the mvn calls that are done internally by gitflow-maven-plugin to call versions-maven-plugin do not pass over the maven settings that are used for the main maven call. this may create problems in other scenarios as well, in this case a handed over the invoker test maven settings manually via argLine in the integration tests.

Fixes #64 