### PR TITLE
Hotfix Finish support without parameter hotfixBranch

### DIFF
--- a/src/it/hotfix-finish-6-it/expected-development-pom.xml
+++ b/src/it/hotfix-finish-6-it/expected-development-pom.xml
@@ -1,0 +1,7 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.amashchenko.maven.plugin</groupId>
+    <artifactId>gitflow-maven-test</artifactId>
+    <packaging>pom</packaging>
+    <version>0.0.4-SNAPSHOT</version>
+</project>

--- a/src/it/hotfix-finish-6-it/expected-production-pom.xml
+++ b/src/it/hotfix-finish-6-it/expected-production-pom.xml
@@ -1,0 +1,7 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.amashchenko.maven.plugin</groupId>
+    <artifactId>gitflow-maven-test</artifactId>
+    <packaging>pom</packaging>
+    <version>0.0.4</version>
+</project>

--- a/src/it/hotfix-finish-6-it/gitignorefile
+++ b/src/it/hotfix-finish-6-it/gitignorefile
@@ -1,0 +1,6 @@
+build.log
+expected-development-pom.xml
+expected-production-pom.xml
+invoker.properties
+init.bsh
+verify.bsh

--- a/src/it/hotfix-finish-6-it/init.bsh
+++ b/src/it/hotfix-finish-6-it/init.bsh
@@ -1,0 +1,41 @@
+import org.codehaus.plexus.util.FileUtils;
+
+try {
+    new File(basedir, "gitignorefile").renameTo(new File(basedir, ".gitignore"));
+
+    Process p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " init");
+    p.waitFor();
+
+    Process p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " config user.email 'a@a.aa'");
+    p.waitFor();
+    Process p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " config user.name 'a'");
+    p.waitFor();
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " add .");
+    p.waitFor();
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " commit -m init");
+    p.waitFor();
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " checkout -b develop");
+    p.waitFor();
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " checkout -b hotfix/0.0.4");
+    p.waitFor();
+
+    File pomfile = new File(basedir, "pom.xml");
+    String pomfilestr = FileUtils.fileRead(pomfile, "UTF-8");
+    pomfilestr = pomfilestr.replaceAll("0.0.3", "0.0.4");
+    FileUtils.fileWrite(basedir + "/pom.xml", "UTF-8", pomfilestr);
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " add .");
+    p.waitFor();
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " commit -m next");
+    p.waitFor();
+
+} catch (Exception e) {
+    e.printStackTrace();
+    return false;
+}
+return true;

--- a/src/it/hotfix-finish-6-it/invoker.properties
+++ b/src/it/hotfix-finish-6-it/invoker.properties
@@ -1,0 +1,3 @@
+invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:hotfix-finish -DpushRemote=false -B
+
+invoker.description=Non-interactive hotfix-finish without using hotfixBranch parameter.

--- a/src/it/hotfix-finish-6-it/pom.xml
+++ b/src/it/hotfix-finish-6-it/pom.xml
@@ -1,0 +1,7 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.amashchenko.maven.plugin</groupId>
+    <artifactId>gitflow-maven-test</artifactId>
+    <packaging>pom</packaging>
+    <version>0.0.3</version>
+</project>

--- a/src/it/hotfix-finish-6-it/verify.bsh
+++ b/src/it/hotfix-finish-6-it/verify.bsh
@@ -1,0 +1,38 @@
+import org.codehaus.plexus.util.FileUtils;
+
+try {
+    File gitRef = new File(basedir, ".git/refs/heads/hotfix/0.0.4");
+    if (gitRef.exists()) {
+        System.out.println("hotfix-finish .git/refs/heads/hotfix/0.0.4 exists");
+        return false;
+    }
+
+    File file = new File(basedir, "pom.xml");
+    File expectedFile = new File(basedir, "expected-development-pom.xml");
+
+    String actual = FileUtils.fileRead(file, "UTF-8");
+    String expected = FileUtils.fileRead(expectedFile, "UTF-8");
+
+    if (!expected.equals(actual)) {
+        System.out.println("hotfix-finish expected: " + expected + " actual was:" + actual);
+        return false;
+    }
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " checkout master");
+    p.waitFor();
+
+    file = new File(basedir, "pom.xml");
+    expectedFile = new File(basedir, "expected-production-pom.xml");
+
+    actual = FileUtils.fileRead(file, "UTF-8");
+    expected = FileUtils.fileRead(expectedFile, "UTF-8");
+
+    if (!expected.equals(actual)) {
+        System.out.println("hotfix-finish expected: " + expected + " actual was:" + actual);
+        return false;
+    }
+} catch (Exception e) {
+    e.printStackTrace();
+    return false;
+}
+return true;


### PR DESCRIPTION
Implementation of ticket #326. This allows to close a hotfix branch in batch mode without specifying the parameter hotfixBranch, if only one hotfix branch is available. 