### PR TITLE
Call initExecutables before usage of output

### DIFF
--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
@@ -50,7 +50,6 @@ import org.codehaus.plexus.util.cli.Commandline;
 
 /**
  * Abstract git flow mojo.
- * 
  */
 public abstract class AbstractGitFlowMojo extends AbstractMojo {
     /** Group and artifact id of the versions-maven-plugin. */
@@ -89,7 +88,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Git commit messages.
-     * 
+     *
      * @since 1.2.1
      */
     @Parameter(defaultValue = "${commitMessages}")
@@ -97,15 +96,15 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Whether this is Tycho build.
-     * 
+     *
      * @since 1.1.0
      */
     @Parameter(defaultValue = "false")
     protected boolean tychoBuild;
-    
+
     /**
      * Whether to call Maven install goal during the mojo execution.
-     * 
+     *
      * @since 1.0.5
      */
     @Parameter(property = "installProject", defaultValue = "false")
@@ -113,7 +112,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Whether to fetch remote branch and compare it with the local one.
-     * 
+     *
      * @since 1.3.0
      */
     @Parameter(property = "fetchRemote", defaultValue = "true")
@@ -121,7 +120,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Whether to print commands output into the console.
-     * 
+     *
      * @since 1.0.7
      */
     @Parameter(property = "verbose", defaultValue = "false")
@@ -129,7 +128,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Command line arguments to pass to the underlying Maven commands.
-     * 
+     *
      * @since 1.8.0
      */
     @Parameter(property = "argLine")
@@ -137,7 +136,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Whether to make a GPG-signed commit.
-     * 
+     *
      * @since 1.9.0
      */
     @Parameter(property = "gpgSignCommit", defaultValue = "false")
@@ -146,7 +145,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
     /**
      * Whether to set -DgroupId='*' -DartifactId='*' when calling
      * versions-maven-plugin.
-     * 
+     *
      * @since 1.10.0
      */
     @Parameter(property = "versionsForceUpdate", defaultValue = "false")
@@ -163,7 +162,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
     /**
      * Whether to skip updating version. Useful with {@link #versionProperty} to be
      * able to update <code>revision</code> property without modifying version tag.
-     * 
+     *
      * @since 1.13.0
      */
     @Parameter(property = "skipUpdateVersion")
@@ -171,7 +170,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Prefix that is applied to commit messages.
-     * 
+     *
      * @since 1.14.0
      */
     @Parameter(property = "commitMessagePrefix")
@@ -200,7 +199,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Version of versions-maven-plugin to use.
-     * 
+     *
      * @since 1.18.0
      */
     @Parameter(property = "versionsMavenPluginVersion", defaultValue = "2.8.1")
@@ -208,7 +207,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Version of tycho-versions-plugin to use.
-     * 
+     *
      * @since 1.18.0
      */
     @Parameter(property = "tychoVersionsPluginVersion", defaultValue = "0.24.0")
@@ -219,7 +218,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
      * Multiple options can be added separated with a space e.g.
      * <code>-DgitPushOptions="merge_request.create merge_request.target=develop
      * merge_request.label='Super feature'"</code>
-     * 
+     *
      * @since 1.18.0
      */
     @Parameter(property = "gitPushOptions")
@@ -242,7 +241,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     @Component
     protected ProjectBuilder projectBuilder;
-    
+
     /** Default prompter. */
     @Component
     protected Prompter prompter;
@@ -255,7 +254,6 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Initializes command line executables.
-     * 
      */
     private void initExecutables() {
         if (StringUtils.isBlank(cmdMvn.getExecutable())) {
@@ -282,7 +280,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
     /**
      * Validates plugin configuration. Throws exception if configuration is not
      * valid.
-     * 
+     *
      * @param params
      *            Configuration parameters to validate.
      * @throws MojoFailureException
@@ -308,7 +306,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Gets current project version from pom.xml file.
-     * 
+     *
      * @return Current project version.
      * @throws MojoFailureException
      *          If current project version cannot be obtained.
@@ -325,7 +323,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
     /**
      * Gets current project {@link #REPRODUCIBLE_BUILDS_PROPERTY} property value
      * from pom.xml file.
-     * 
+     *
      * @return Value of {@link #REPRODUCIBLE_BUILDS_PROPERTY} property.
      * @throws MojoFailureException
      *             If project loading fails.
@@ -337,7 +335,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Reloads project info from file
-     * 
+     *
      * @param project
      * @return
      * @throws MojoFailureException
@@ -364,7 +362,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Compares the production branch name with the development branch name.
-     * 
+     *
      * @return <code>true</code> if the production branch name is different from
      *         the development branch name, <code>false</code> otherwise.
      */
@@ -375,7 +373,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Checks uncommitted changes.
-     * 
+     *
      * @throws MojoFailureException
      *             If there is some uncommitted files.
      * @throws CommandLineException
@@ -430,7 +428,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Checks if branch name is acceptable.
-     * 
+     *
      * @param branchName
      *            Branch name to check.
      * @return <code>true</code> when name is valid, <code>false</code> otherwise.
@@ -447,7 +445,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git commands to check for uncommitted changes.
-     * 
+     *
      * @return <code>true</code> when there are uncommitted changes,
      *         <code>false</code> otherwise.
      * @throws CommandLineException
@@ -489,7 +487,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git config commands to set Git Flow configuration.
-     * 
+     *
      * @throws MojoFailureException
      *             Shouldn't happen, actually.
      * @throws CommandLineException
@@ -511,7 +509,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git config command.
-     * 
+     *
      * @param name
      *            Option name.
      * @param value
@@ -533,7 +531,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git for-each-ref with <code>refname:short</code> format.
-     * 
+     *
      * @param branchName
      *            Branch name to find.
      * @param firstMatch
@@ -551,7 +549,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git for-each-ref with <code>refname:short</code> format.
-     * 
+     *
      * @param refs
      *            Refs to search.
      * @param branchName
@@ -627,7 +625,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Removes double quotes from the string.
-     * 
+     *
      * @param str
      *            String to remove quotes from.
      * @return String without quotes.
@@ -638,7 +636,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Gets the current branch name.
-     * 
+     *
      * @return Current branch name.
      * @throws MojoFailureException
      *             If command line execution returns false code.
@@ -745,7 +743,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Replaces properties in message.
-     * 
+     *
      * @param message
      * @param map
      *            Key is a string to replace wrapped in <code>@{...}</code>. Value
@@ -763,7 +761,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git commit -a -m.
-     * 
+     *
      * @param message
      *            Commit message.
      * @throws MojoFailureException
@@ -778,7 +776,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
     /**
      * Executes git commit -a -m, replacing <code>@{map.key}</code> with
      * <code>map.value</code>.
-     * 
+     *
      * @param message
      *            Commit message.
      * @param messageProperties
@@ -809,7 +807,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git rebase or git merge --ff-only or git merge --no-ff or git merge.
-     * 
+     *
      * @param branchName
      *            Branch name to merge.
      * @param rebase
@@ -861,7 +859,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git merge --no-ff.
-     * 
+     *
      * @param branchName
      *            Branch name to merge.
      * @param message
@@ -881,7 +879,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git merge --squash.
-     * 
+     *
      * @param branchName
      *            Branch name to merge.
      * @throws MojoFailureException
@@ -897,7 +895,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git tag -a [-s] -m.
-     * 
+     *
      * @param tagName
      *            Name of the tag.
      * @param message
@@ -928,7 +926,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git branch -d.
-     * 
+     *
      * @param branchName
      *            Branch name to delete.
      * @throws MojoFailureException
@@ -945,7 +943,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git branch -D.
-     * 
+     *
      * @param branchName
      *            Branch name to delete.
      * @throws MojoFailureException
@@ -962,7 +960,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Fetches and checkouts from remote if local branch doesn't exist.
-     * 
+     *
      * @param branchName
      *            Branch name to check.
      * @throws MojoFailureException
@@ -985,7 +983,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git fetch and compares local branch with the remote.
-     * 
+     *
      * @param branchName
      *            Branch name to fetch and compare.
      * @throws MojoFailureException
@@ -1016,7 +1014,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
     /**
      * Executes git fetch and git for-each-ref with <code>refname:short</code>
      * format. Searches <code>refs/remotes/{remoteName}/</code>.
-     * 
+     *
      * @param remoteName
      *            Name of the remote.
      * @param branchName
@@ -1037,7 +1035,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git fetch.
-     * 
+     *
      * @return <code>true</code> if git fetch returned success exit code,
      *         <code>false</code> otherwise.
      * @throws MojoFailureException
@@ -1051,7 +1049,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git fetch with specific branch.
-     * 
+     *
      * @param branchName
      *            Branch name to fetch.
      * @return <code>true</code> if git fetch returned success exit code,
@@ -1082,7 +1080,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git push, optionally with the <code>--follow-tags</code> argument.
-     * 
+     *
      * @param branchName
      *            Branch name to push.
      * @param pushTags
@@ -1139,7 +1137,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
     /**
      * Executes 'set' goal of versions-maven-plugin or 'set-version' of
      * tycho-versions-plugin in case it is tycho build.
-     * 
+     *
      * @param version
      *            New version to set.
      * @throws MojoFailureException
@@ -1216,7 +1214,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes mvn clean test.
-     * 
+     *
      * @throws MojoFailureException
      *             If command line execution returns false code.
      * @throws CommandLineException
@@ -1234,7 +1232,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes mvn clean install.
-     * 
+     *
      * @throws MojoFailureException
      *             If command line execution returns false code.
      * @throws CommandLineException
@@ -1249,7 +1247,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes Maven goals.
-     * 
+     *
      * @param goals
      *            The goals to execute.
      * @throws Exception
@@ -1263,7 +1261,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes Git command and returns output.
-     * 
+     *
      * @param args
      *            Git command line arguments.
      * @return Command output.
@@ -1274,12 +1272,17 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
      */
     private String executeGitCommandReturn(final String... args)
             throws CommandLineException, MojoFailureException {
-        return executeCommand(cmdGit, true, null, args).getOut();
+
+        // initialize executables
+        initExecutables();
+
+        return executeCommand(cmdGit, true, null, args)
+            .getOut();
     }
 
     /**
      * Executes Git command without failing on non successful exit code.
-     * 
+     *
      * @param args
      *            Git command line arguments.
      * @return Command result.
@@ -1290,12 +1293,16 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
      */
     private CommandResult executeGitCommandExitCode(final String... args)
             throws CommandLineException, MojoFailureException {
+
+        // initialize executables
+        initExecutables();
+
         return executeCommand(cmdGit, false, null, args);
     }
 
     /**
      * Executes Git command.
-     * 
+     *
      * @param args
      *            Git command line arguments.
      * @throws CommandLineException
@@ -1305,12 +1312,16 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
      */
     private void executeGitCommand(final String... args)
             throws CommandLineException, MojoFailureException {
+
+        // initialize executables
+        initExecutables();
+
         executeCommand(cmdGit, true, null, args);
     }
 
     /**
      * Executes Maven command.
-     * 
+     *
      * @param args
      *            Maven command line arguments.
      * @throws CommandLineException
@@ -1320,12 +1331,16 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
      */
     private void executeMvnCommand(final String... args)
             throws CommandLineException, MojoFailureException {
+
+        // initialize executables
+        initExecutables();
+
         executeCommand(cmdMvn, true, argLine, args);
     }
 
     /**
      * Executes command line.
-     * 
+     *
      * @param cmd
      *            Command line.
      * @param failOnError
@@ -1343,11 +1358,9 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
      *             code is NOT equals to 0.
      */
     private CommandResult executeCommand(final Commandline cmd,
-            final boolean failOnError, final String argStr,
-            final String... args) throws CommandLineException,
-            MojoFailureException {
-        // initialize executables
-        initExecutables();
+                                         final boolean failOnError, final String argStr,
+                                         final String... args)
+            throws CommandLineException, MojoFailureException {
 
         if (getLog().isDebugEnabled()) {
             getLog().debug(


### PR DESCRIPTION
Looking at the Global Settings, User Settings, Maven Wrapper, refactor existing code so `initExecutables()` before usage of `cmdGit` or `cmdMvn`.