### PR TITLE
Add updateSubmodulesBeforeCommit option (fixes #348)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ The `gitflow:release`, `gitflow:release-finish` and `gitflow:hotfix-finish` goal
 
 All goals have `gpgSignCommit` parameter. Set it to `true` to sign commits with configured personal key. The default value is `false`.
 
+### Updating submodules before commit
+
+All goals have `updateSubmodulesBeforeCommit` parameter. Set it to `true` to run `git submodule update` before the plugin commits any changes. The default value is `true`.
 
 # Support for Reproducible Builds
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <artifactId>gitflow-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
     <name>gitflow-maven-plugin</name>
-    <version>1.18.1-SNAPSHOT</version>
+    <version>1.19.0-SNAPSHOT</version>
 
     <description>The Git-Flow Maven Plugin supports various Git workflows, including Vincent Driessen's successful Git branching model and GitHub Flow. This plugin runs Git and Maven commands from the command line. Supports Eclipse Plugins build with Tycho.</description>
 

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
@@ -144,6 +144,14 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
     private boolean gpgSignCommit = false;
 
     /**
+     * Whether to update submodules before commit.
+     *
+     * @since 1.19.0
+     */
+    @Parameter(property = "updateSubmodulesBeforeCommit", defaultValue = "true")
+    private boolean updateSubmodulesBeforeCommit = true;
+
+    /**
      * Whether to set -DgroupId='*' -DartifactId='*' when calling
      * versions-maven-plugin.
      * 
@@ -795,6 +803,11 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
         }
 
         message = replaceProperties(message, messageProperties);
+
+        if (updateSubmodulesBeforeCommit) {
+            getLog().info("Updating submodules before commit.");
+            executeGitCommand("submodule", "update");
+        }
 
         if (gpgSignCommit) {
             getLog().info("Committing changes. GPG-signed.");


### PR DESCRIPTION
This option makes the plugin perform `git submodule update` before each commit. This is useful because, without it, the plugin ends up overriding submodule references upon closing hotfix/feature/release branches (#348).