### PR TITLE
Get develop version from branch develop during feature-finish

### DIFF
--- a/src/it/feature-finish-2-it/init.bsh
+++ b/src/it/feature-finish-2-it/init.bsh
@@ -1,3 +1,5 @@
+import org.codehaus.plexus.util.FileUtils;
+
 try {
     new File(basedir, "gitignorefile").renameTo(new File(basedir, ".gitignore"));
 
@@ -19,6 +21,17 @@ try {
     p.waitFor();
 
     p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " checkout -b develop");
+    p.waitFor();
+
+    File pomfile = new File(basedir, "pom.xml");
+    String pomfilestr = FileUtils.fileRead(pomfile, "UTF-8");
+    pomfilestr = pomfilestr.replaceAll("0.0.3-test-SNAPSHOT", "0.0.3-SNAPSHOT");
+    FileUtils.fileWrite(basedir + "/pom.xml", "UTF-8", pomfilestr);
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " add pom.xml");
+    p.waitFor();
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " commit -m set-dev-version");
     p.waitFor();
 
 } catch (Exception e) {

--- a/src/it/feature-finish-3-it/init.bsh
+++ b/src/it/feature-finish-3-it/init.bsh
@@ -1,3 +1,5 @@
+import org.codehaus.plexus.util.FileUtils;
+
 try {
     new File(basedir, "gitignorefile").renameTo(new File(basedir, ".gitignore"));
 
@@ -15,10 +17,24 @@ try {
     p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " commit -m init");
     p.waitFor();
 
-    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " branch feature/ISSUE-288");
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " branch develop");
     p.waitFor();
 
-    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " checkout -b develop");
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " checkout -b feature/ISSUE-288");
+    p.waitFor();
+
+    File pomfile = new File(basedir, "pom.xml");
+    String pomfilestr = FileUtils.fileRead(pomfile, "UTF-8");
+    pomfilestr = pomfilestr.replaceAll("0.0.3-SNAPSHOT", "0.0.3-ISSUE-288-SNAPSHOT");
+    FileUtils.fileWrite(basedir + "/pom.xml", "UTF-8", pomfilestr);
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " add pom.xml");
+    p.waitFor();
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " commit -m set-feature-version");
+    p.waitFor();
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " checkout develop");
     p.waitFor();
 
 } catch (Exception e) {

--- a/src/it/feature-finish-3-it/pom.xml
+++ b/src/it/feature-finish-3-it/pom.xml
@@ -3,5 +3,5 @@
     <groupId>com.amashchenko.maven.plugin</groupId>
     <artifactId>gitflow-maven-test</artifactId>
     <packaging>pom</packaging>
-    <version>0.0.3-ISSUE-288-SNAPSHOT</version>
+    <version>0.0.3-SNAPSHOT</version>
 </project>

--- a/src/it/feature-finish-4-it/expected-pom.xml
+++ b/src/it/feature-finish-4-it/expected-pom.xml
@@ -1,0 +1,7 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.amashchenko.maven.plugin</groupId>
+    <artifactId>gitflow-maven-test</artifactId>
+    <packaging>pom</packaging>
+    <version>0.0.4-SNAPSHOT</version>
+</project>

--- a/src/it/feature-finish-4-it/gitignorefile
+++ b/src/it/feature-finish-4-it/gitignorefile
@@ -1,0 +1,5 @@
+build.log
+expected-pom.xml
+invoker.properties
+init.bsh
+verify.bsh

--- a/src/it/feature-finish-4-it/init.bsh
+++ b/src/it/feature-finish-4-it/init.bsh
@@ -1,0 +1,51 @@
+import org.codehaus.plexus.util.FileUtils;
+
+try {
+    new File(basedir, "gitignorefile").renameTo(new File(basedir, ".gitignore"));
+
+    Process p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " init");
+    p.waitFor();
+
+    Process p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " config user.email 'a@a.aa'");
+    p.waitFor();
+    Process p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " config user.name 'a'");
+    p.waitFor();
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " add .");
+    p.waitFor();
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " commit -m init");
+    p.waitFor();
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " checkout -b feature/test");
+    p.waitFor();
+
+    File pomfile = new File(basedir, "pom.xml");
+    String pomfilestr = FileUtils.fileRead(pomfile, "UTF-8");
+    pomfilestr = pomfilestr.replaceAll("0.0.3-SNAPSHOT", "0.0.3-test-SNAPSHOT");
+    FileUtils.fileWrite(basedir + "/pom.xml", "UTF-8", pomfilestr);
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " add pom.xml");
+    p.waitFor();
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " commit -m set-feature-version");
+    p.waitFor();
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " checkout -b develop");
+    p.waitFor();
+
+    String pomfilestr = FileUtils.fileRead(pomfile, "UTF-8");
+    pomfilestr = pomfilestr.replaceAll("0.0.3-test-SNAPSHOT", "0.0.4-SNAPSHOT");
+    FileUtils.fileWrite(basedir + "/pom.xml", "UTF-8", pomfilestr);
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " add pom.xml");
+    p.waitFor();
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " commit -m next-dev-version");
+    p.waitFor();
+
+} catch (Exception e) {
+    e.printStackTrace();
+    return false;
+}
+return true;

--- a/src/it/feature-finish-4-it/invoker.properties
+++ b/src/it/feature-finish-4-it/invoker.properties
@@ -1,0 +1,3 @@
+invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:feature-finish -DpushRemote=false -B -DfeatureName=test
+
+invoker.description=Non-interactive feature-finish.

--- a/src/it/feature-finish-4-it/pom.xml
+++ b/src/it/feature-finish-4-it/pom.xml
@@ -1,0 +1,7 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.amashchenko.maven.plugin</groupId>
+    <artifactId>gitflow-maven-test</artifactId>
+    <packaging>pom</packaging>
+    <version>0.0.3-SNAPSHOT</version>
+</project>

--- a/src/it/feature-finish-4-it/verify.bsh
+++ b/src/it/feature-finish-4-it/verify.bsh
@@ -1,0 +1,27 @@
+import org.codehaus.plexus.util.FileUtils;
+
+try {
+    File gitRef = new File(basedir, ".git/refs/heads/feature/test");
+    if (gitRef.exists()) {
+        System.out.println("feature-finish .git/refs/heads/feature/test exists");
+        return false;
+    }
+
+    File file = new File(basedir, "pom.xml");
+    File expectedFile = new File(basedir, "expected-pom.xml");
+
+    String actual = FileUtils.fileRead(file, "UTF-8");
+    String expected = FileUtils.fileRead(expectedFile, "UTF-8");
+
+    actual = actual.replaceAll("\\r?\\n", "");
+    expected = expected.replaceAll("\\r?\\n", "");
+
+    if (!expected.equals(actual)) {
+        System.out.println("feature-finish expected: " + expected + " actual was:" + actual);
+        return false;
+    }
+} catch (Exception e) {
+    e.printStackTrace();
+    return false;
+}
+return true;

--- a/src/it/feature-finish-it/init.bsh
+++ b/src/it/feature-finish-it/init.bsh
@@ -1,3 +1,5 @@
+import org.codehaus.plexus.util.FileUtils;
+
 try {
     new File(basedir, "gitignorefile").renameTo(new File(basedir, ".gitignore"));
 
@@ -19,6 +21,17 @@ try {
     p.waitFor();
 
     p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " checkout -b develop");
+    p.waitFor();
+
+    File pomfile = new File(basedir, "pom.xml");
+    String pomfilestr = FileUtils.fileRead(pomfile, "UTF-8");
+    pomfilestr = pomfilestr.replaceAll("0.0.3-test-SNAPSHOT", "0.0.3-SNAPSHOT");
+    FileUtils.fileWrite(basedir + "/pom.xml", "UTF-8", pomfilestr);
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " add pom.xml");
+    p.waitFor();
+
+    p = Runtime.getRuntime().exec("git --git-dir=" + basedir + "/.git --work-tree=" + basedir + " commit -m set-dev-version");
     p.waitFor();
 
 } catch (Exception e) {

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowFeatureFinishMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowFeatureFinishMojo.java
@@ -30,7 +30,7 @@ import org.codehaus.plexus.util.cli.CommandLineException;
 
 /**
  * The git flow feature finish mojo.
- * 
+ *
  */
 @Mojo(name = "feature-finish", aggregator = true)
 public class GitFlowFeatureFinishMojo extends AbstractGitFlowMojo {
@@ -41,7 +41,7 @@ public class GitFlowFeatureFinishMojo extends AbstractGitFlowMojo {
 
     /**
      * Whether to skip calling Maven test goal before merging the branch.
-     * 
+     *
      * @since 1.0.5
      */
     @Parameter(property = "skipTestProject", defaultValue = "false")
@@ -50,7 +50,7 @@ public class GitFlowFeatureFinishMojo extends AbstractGitFlowMojo {
     /**
      * Whether to squash feature branch commits into a single commit upon
      * merging.
-     * 
+     *
      * @since 1.2.3
      */
     @Parameter(property = "featureSquash", defaultValue = "false")
@@ -58,7 +58,7 @@ public class GitFlowFeatureFinishMojo extends AbstractGitFlowMojo {
 
     /**
      * Whether to push to the remote.
-     * 
+     *
      * @since 1.3.0
      */
     @Parameter(property = "pushRemote", defaultValue = "true")
@@ -66,7 +66,7 @@ public class GitFlowFeatureFinishMojo extends AbstractGitFlowMojo {
 
     /**
      * Feature name, without feature branch prefix, to use in non-interactive mode.
-     * 
+     *
      * @since 1.9.0
      */
     @Parameter(property = "featureName")
@@ -76,7 +76,7 @@ public class GitFlowFeatureFinishMojo extends AbstractGitFlowMojo {
      * Feature branch to use in non-interactive mode. Must start with feature branch
      * prefix. The featureBranch parameter will be used instead of
      * {@link #featureName} if both are set.
-     * 
+     *
      * @since 1.16.0
      */
     @Parameter(property = "featureBranch")
@@ -147,6 +147,9 @@ public class GitFlowFeatureFinishMojo extends AbstractGitFlowMojo {
                 gitFetchRemoteAndCompareCreate(gitFlowConfig.getDevelopmentBranch());
             }
 
+            gitCheckout(gitFlowConfig.getDevelopmentBranch());
+            final String devVersion = getCurrentProjectVersion();
+
             // git checkout feature/...
             gitCheckout(featureBranchName);
 
@@ -164,11 +167,10 @@ public class GitFlowFeatureFinishMojo extends AbstractGitFlowMojo {
 
             final String featName = featureBranchName.replaceFirst(gitFlowConfig.getFeatureBranchPrefix(), "");
 
+            final String version;
             if (incrementVersionAtFinish) {
-                // prevent incrementing feature name which can hold numbers
-                String ver = featureVersion.replaceFirst("-" + featName, "");
-                GitFlowVersionInfo nextVersionInfo = new GitFlowVersionInfo(ver, getVersionPolicy());
-                ver = nextVersionInfo.nextSnapshotVersion();
+                GitFlowVersionInfo nextVersionInfo = new GitFlowVersionInfo(devVersion, getVersionPolicy());
+                String ver = nextVersionInfo.nextSnapshotVersion();
                 GitFlowVersionInfo featureVersionInfo = new GitFlowVersionInfo(ver, getVersionPolicy());
                 featureVersion = featureVersionInfo.featureVersion(featName);
 
@@ -178,11 +180,13 @@ public class GitFlowFeatureFinishMojo extends AbstractGitFlowMojo {
                 properties.put("version", featureVersion);
                 properties.put("featureName", featName);
                 gitCommit(commitMessages.getFeatureFinishIncrementVersionMessage(), properties);
+                version = ver;
+            } else {
+                version = devVersion;
             }
 
             final String keptFeatureVersion = featureVersion;
 
-            final String version = keptFeatureVersion.replaceFirst("-" + featName, "");
             if (keptFeatureVersion.contains("-" + featName)) {
                 // mvn versions:set -DnewVersion=... -DgenerateBackupPoms=false
                 mvnSetVersions(version);


### PR DESCRIPTION
Hi,

Currently, feature-finish deduces the version from the name of the feature branch version.
This assumes that the version of develop didn't change.
I think we can't make this assumption, and should instead fetch the version from the development branch, which will always be correct.

As taking the version from the branch develop is always correct, I think this PR makes #239 obsolete.

closes #147