### PR TITLE
Java8 baseline & bump all dependencies

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -10,16 +10,16 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v3
 
-      - name: Set up JDK 7
-        uses: actions/setup-java@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v3
         with:
-          distribution: 'zulu'
-          java-version: 7
+          distribution: 'temurin'
+          java-version: 8
 
       - name: Set up Maven
         uses: stCarolas/setup-maven@v4.5
         with:
-          maven-version: 3.8.4
+          maven-version: 3.9.1
 
       - name: Cache Maven packages
         uses: actions/cache@v3

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -34,5 +34,5 @@ jobs:
       - uses: actions/upload-artifact@v3
         if: failure()
         with:
-          name: it-build-logs
+          name: ${{ runner.os }}-it-build-logs
           path: target/it/*/*.log

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -5,14 +5,14 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.4/apache-maven-3.8.4-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.0/maven-wrapper-3.1.0.jar
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.1/apache-maven-3.9.1-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -63,9 +63,9 @@
     </distributionManagement>
 
     <properties>
-        <java.version>1.7</java.version>
+        <java.version>8</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven-plugin-plugin.version>3.6.0</maven-plugin-plugin.version>
+        <maven-plugin-plugin.version>3.8.2</maven-plugin-plugin.version>
     </properties>
 
     <reporting>
@@ -99,7 +99,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.11.0</version>
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
@@ -109,7 +109,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.3.1</version>
+                <version>3.5.0</version>
                 <configuration>
                     <source>${java.version}</source>
                 </configuration>
@@ -117,7 +117,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
-                <version>3.7.1</version>
+                <version>3.12.1</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -153,7 +153,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>3.1.0</version>
+                        <version>3.2.1</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
@@ -178,7 +178,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.6</version>
+                        <version>3.0.1</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -198,7 +198,7 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-invoker-plugin</artifactId>
-                        <version>3.2.2</version>
+                        <version>3.5.1</version>
                         <configuration>
                             <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
                             <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
@@ -224,35 +224,30 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
-            <version>3.8.5</version>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-utils</artifactId>
-            <version>1.5.15</version><!-- cannot go to 3.X without breaking java7 compatibiltiy -->
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven.plugin-tools</groupId>
-            <artifactId>maven-plugin-annotations</artifactId>
-            <version>3.6.4</version>
+            <version>3.9.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-interactivity-api</artifactId>
-            <version>1.1</version>
-            <scope>compile</scope>
+            <artifactId>plexus-utils</artifactId>
+            <version>3.5.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugin-tools</groupId>
+            <artifactId>maven-plugin-annotations</artifactId>
+            <version>3.8.2</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.release</groupId>
             <artifactId>maven-release-manager</artifactId>
-            <version>2.5.3</version>
+            <version>3.0.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.release</groupId>
             <artifactId>maven-release-oddeven-policy</artifactId>
-            <version>2.5.3</version>
+            <version>3.0.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -251,9 +251,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.2</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.9.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
@@ -18,6 +18,7 @@ package com.amashchenko.maven.plugin.gitflow;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
@@ -25,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TimeZone;
 import java.util.regex.Pattern;
@@ -854,12 +856,12 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
     protected void gitMerge(final String branchName, boolean rebase, boolean noff, boolean ffonly, String message,
             Map<String, String> messageProperties)
             throws MojoFailureException, CommandLineException {
-        String sign = "";
+        String sign = null;
         if (gpgSignCommit) {
             sign = "-S";
         }
-        String msgParam = "";
-        String msg = "";
+        String msgParam = null;
+        String msg = null;
         if (StringUtils.isNotBlank(message)) {
             if (StringUtils.isNotBlank(commitMessagePrefix)) {
                 message = commitMessagePrefix + message;
@@ -1129,15 +1131,9 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
         getLog().info("Updating version(s) to '" + version + "'.");
 
         String newVersion = "-DnewVersion=" + version;
-        String grp = "";
-        String art = "";
-        if (versionsForceUpdate) {
-            grp = "-DgroupId=";
-            art = "-DartifactId=";
-        }
 
         if (tychoBuild) {
-            String prop = "";
+            String prop = null;
             if (StringUtils.isNotBlank(versionProperty)) {
                 prop = "-Dproperties=" + versionProperty;
                 getLog().info("Updating property '" + versionProperty + "' to '" + version + "'.");
@@ -1153,8 +1149,10 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
             if (!skipUpdateVersion) {
                 runCommand = true;
                 args.add(VERSIONS_MAVEN_PLUGIN + ":" + versionsMavenPluginVersion + ":" + VERSIONS_MAVEN_PLUGIN_SET_GOAL);
-                args.add(grp);
-                args.add(art);
+                if (versionsForceUpdate) {
+                    args.add("-DgroupId=");
+                    args.add("-DartifactId=");
+                }
             }
 
             if (StringUtils.isNotBlank(versionProperty)) {
@@ -1330,7 +1328,8 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
         }
 
         cmd.clearArgs();
-        cmd.addArguments(args);
+        String[] nonNullArgs = Arrays.stream(args).filter(Objects::nonNull).toArray(String[]::new);
+        cmd.addArguments(nonNullArgs);
 
         if (StringUtils.isNotBlank(argStr)) {
             cmd.createArg().setLine(argStr);

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
@@ -44,6 +44,7 @@ import org.apache.maven.settings.Settings;
 import org.apache.maven.shared.release.policy.version.VersionPolicy;
 import org.codehaus.plexus.components.interactivity.Prompter;
 import org.codehaus.plexus.util.FileUtils;
+import org.codehaus.plexus.util.Os;
 import org.codehaus.plexus.util.StringUtils;
 import org.codehaus.plexus.util.cli.CommandLineException;
 import org.codehaus.plexus.util.cli.CommandLineUtils;
@@ -546,7 +547,12 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
      */
     private void gitSetConfig(final String name, String value) throws MojoFailureException, CommandLineException {
         if (value == null || value.isEmpty()) {
-            value = "\"\"";
+            if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                value = "\"\"";
+            }
+            else {
+                value = "";
+            }
         }
 
         // ignore error exit codes
@@ -636,7 +642,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
      *             If command line execution fails.
      */
     protected String gitFindLastTag() throws MojoFailureException, CommandLineException {
-        String tag = executeGitCommandReturn("for-each-ref", "--sort=\"-version:refname\"", "--sort=-taggerdate",
+        String tag = executeGitCommandReturn("for-each-ref", "--sort=-version:refname", "--sort=-taggerdate",
                 "--count=1", "--format=\"%(refname:short)\"", "refs/tags/");
         // https://github.com/aleksandr-m/gitflow-maven-plugin/issues/3
         tag = removeQuotes(tag);

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
@@ -1344,7 +1344,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
             // not all commands print errors to error stream
             errorStr += LS + outStr;
 
-            throw new MojoFailureException(errorStr);
+            throw new MojoFailureException("Failed cmd ["+cmd.getExecutable()+"] with args [" + Arrays.toString(cmd.getArguments()) + "], bad exit code [" + exitCode +"]. Out: [" + errorStr+ "]");
         }
 
         if (verbose && StringUtils.isNotBlank(errorStr)) {

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
@@ -206,16 +206,16 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
      * 
      * @since 1.18.0
      */
-    @Parameter(property = "versionsMavenPluginVersion", defaultValue = "2.8.1")
-    private String versionsMavenPluginVersion = "2.8.1";
+    @Parameter(property = "versionsMavenPluginVersion", defaultValue = "2.14.2")
+    private String versionsMavenPluginVersion = "2.24.2";
 
     /**
      * Version of tycho-versions-plugin to use.
      * 
      * @since 1.18.0
      */
-    @Parameter(property = "tychoVersionsPluginVersion", defaultValue = "0.24.0")
-    private String tychoVersionsPluginVersion = "0.24.0";
+    @Parameter(property = "tychoVersionsPluginVersion", defaultValue = "1.7.0")
+    private String tychoVersionsPluginVersion = "1.7.0";
 
     /**
      * Options to pass to Git push command using <code>--push-option</code>.

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
@@ -209,8 +209,8 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
      * 
      * @since 1.18.0
      */
-    @Parameter(property = "versionsMavenPluginVersion", defaultValue = "2.14.2")
-    private String versionsMavenPluginVersion = "2.24.2";
+    @Parameter(property = "versionsMavenPluginVersion", defaultValue = "2.15.0")
+    private String versionsMavenPluginVersion = "2.25.0";
 
     /**
      * Version of tycho-versions-plugin to use.

--- a/src/test/java/com/amashchenko/maven/plugin/gitflow/FeatureVersionTest.java
+++ b/src/test/java/com/amashchenko/maven/plugin/gitflow/FeatureVersionTest.java
@@ -18,26 +18,13 @@ package com.amashchenko.maven.plugin.gitflow;
 import java.util.Arrays;
 import java.util.Collection;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 public class FeatureVersionTest {
-    private final String version;
-    private final String featureName;
-    private final String expectedVersion;
 
-    public FeatureVersionTest(final String version, final String featureName,
-            final String expectedVersion) {
-        this.version = version;
-        this.featureName = featureName;
-        this.expectedVersion = expectedVersion;
-    }
-
-    @Parameters
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][] {
                         { "0.9-SNAPSHOT", "feature", "0.9-feature-SNAPSHOT" },
@@ -48,9 +35,11 @@ public class FeatureVersionTest {
                         { "0.9-RC3", null, "0.9-RC3" } });
     }
 
-    @Test
-    public void testFeatureVersion() throws Exception {
-        Assert.assertEquals(expectedVersion,
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testFeatureVersion(final String version, final String featureName,
+                                   final String expectedVersion) throws Exception {
+        assertEquals(expectedVersion,
                 new GitFlowVersionInfo(version, null).featureVersion(featureName));
     }
 }

--- a/src/test/java/com/amashchenko/maven/plugin/gitflow/GitFlowVersionInfoTest.java
+++ b/src/test/java/com/amashchenko/maven/plugin/gitflow/GitFlowVersionInfoTest.java
@@ -17,105 +17,107 @@ package com.amashchenko.maven.plugin.gitflow;
 
 import org.apache.maven.shared.release.policy.oddeven.OddEvenVersionPolicy;
 import org.apache.maven.shared.release.versions.VersionParseException;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class GitFlowVersionInfoTest {
     @Test
     public void testCreating() throws Exception {
         final String version = "0.9";
         GitFlowVersionInfo info = new GitFlowVersionInfo(version, null);
-        Assert.assertNotNull(info);
-        Assert.assertEquals(version, info.toString());
+        Assertions.assertNotNull(info);
+        Assertions.assertEquals(version, info.toString());
     }
 
-    @Test(expected = VersionParseException.class)
+    @Test
     public void testVersionParseException() throws Exception {
-        new GitFlowVersionInfo("", null);
+        Assertions.assertThrows(VersionParseException.class, ()-> new GitFlowVersionInfo("", null));
     }
 
     @Test
     public void testIsValidVersion() throws Exception {
-        Assert.assertTrue(GitFlowVersionInfo.isValidVersion("0.9"));
-        Assert.assertTrue(GitFlowVersionInfo.isValidVersion("some-SNAPSHOT"));
-        Assert.assertTrue(GitFlowVersionInfo
+        Assertions.assertTrue(GitFlowVersionInfo.isValidVersion("0.9"));
+        Assertions.assertTrue(GitFlowVersionInfo.isValidVersion("some-SNAPSHOT"));
+        Assertions.assertTrue(GitFlowVersionInfo
                 .isValidVersion("0.9-RC3-feature-SNAPSHOT"));
 
-        Assert.assertFalse(GitFlowVersionInfo.isValidVersion("some.0.9"));
-        Assert.assertFalse(GitFlowVersionInfo.isValidVersion(null));
-        Assert.assertFalse(GitFlowVersionInfo.isValidVersion(""));
-        Assert.assertFalse(GitFlowVersionInfo.isValidVersion(" "));
-        Assert.assertFalse(GitFlowVersionInfo.isValidVersion("-1"));
+        Assertions.assertFalse(GitFlowVersionInfo.isValidVersion("some.0.9"));
+        Assertions.assertFalse(GitFlowVersionInfo.isValidVersion(null));
+        Assertions.assertFalse(GitFlowVersionInfo.isValidVersion(""));
+        Assertions.assertFalse(GitFlowVersionInfo.isValidVersion(" "));
+        Assertions.assertFalse(GitFlowVersionInfo.isValidVersion("-1"));
     }
 
     @Test
     public void testHotfixVersion() throws Exception {
         GitFlowVersionInfo info = new GitFlowVersionInfo("0.9", null);
-        Assert.assertNotNull(info);
-        Assert.assertEquals("0.10", info.hotfixVersion(false, null));
+        Assertions.assertNotNull(info);
+        Assertions.assertEquals("0.10", info.hotfixVersion(false, null));
     }
 
     @Test
     public void testHotfixVersion2() throws Exception {
         GitFlowVersionInfo info = new GitFlowVersionInfo("0.9-SNAPSHOT", null);
-        Assert.assertNotNull(info);
-        Assert.assertEquals("0.10", info.hotfixVersion(false, null));
+        Assertions.assertNotNull(info);
+        Assertions.assertEquals("0.10", info.hotfixVersion(false, null));
     }
 
     @Test
     public void testHotfixVersion3() throws Exception {
         GitFlowVersionInfo info = new GitFlowVersionInfo("0.9", null);
-        Assert.assertNotNull(info);
-        Assert.assertEquals("0.10", info.hotfixVersion(true, null));
+        Assertions.assertNotNull(info);
+        Assertions.assertEquals("0.10", info.hotfixVersion(true, null));
     }
 
     @Test
     public void testHotfixVersion4() throws Exception {
         GitFlowVersionInfo info = new GitFlowVersionInfo("0.9-SNAPSHOT", null);
-        Assert.assertNotNull(info);
-        Assert.assertEquals("0.10-SNAPSHOT", info.hotfixVersion(true, null));
+        Assertions.assertNotNull(info);
+        Assertions.assertEquals("0.10-SNAPSHOT", info.hotfixVersion(true, null));
     }
 
     @Test
     public void testDigitsVersionInfo() throws Exception {
         GitFlowVersionInfo info = new GitFlowVersionInfo("0.9", null);
-        Assert.assertNotNull(info);
+        Assertions.assertNotNull(info);
         info = info.digitsVersionInfo();
-        Assert.assertNotNull(info);
-        Assert.assertEquals(new GitFlowVersionInfo("0.9", null), info);
+        Assertions.assertNotNull(info);
+        Assertions.assertEquals(new GitFlowVersionInfo("0.9", null), info);
     }
 
     @Test
     public void testDigitsVersionInfo2() throws Exception {
         GitFlowVersionInfo info = new GitFlowVersionInfo(
                 "0.9-RC3-feature-SNAPSHOT", null);
-        Assert.assertNotNull(info);
+        Assertions.assertNotNull(info);
         info = info.digitsVersionInfo();
-        Assert.assertNotNull(info);
-        Assert.assertEquals(new GitFlowVersionInfo("0.9", null), info);
+        Assertions.assertNotNull(info);
+        Assertions.assertEquals(new GitFlowVersionInfo("0.9", null), info);
     }
 
     @Test
     public void testWithoutVersionPolicy() throws Exception {
         GitFlowVersionInfo info1 = new GitFlowVersionInfo("1.0.0-SNAPSHOT", null);
-        Assert.assertEquals("1.0.0", info1.getReleaseVersionString());
-        Assert.assertEquals("1.0.1-SNAPSHOT", info1.nextSnapshotVersion());
+        Assertions.assertEquals("1.0.0", info1.getReleaseVersionString());
+        Assertions.assertEquals("1.0.1-SNAPSHOT", info1.nextSnapshotVersion());
 
         GitFlowVersionInfo info2 = new GitFlowVersionInfo("1.0.1-SNAPSHOT", null);
-        Assert.assertEquals("1.0.1", info2.getReleaseVersionString());
-        Assert.assertEquals("1.0.2-SNAPSHOT", info2.nextSnapshotVersion());
+        Assertions.assertEquals("1.0.1", info2.getReleaseVersionString());
+        Assertions.assertEquals("1.0.2-SNAPSHOT", info2.nextSnapshotVersion());
     }
 
     @Test
     public void testWithVersionPolicy() throws Exception {
         GitFlowVersionInfo info1 = new GitFlowVersionInfo("1.0.0-SNAPSHOT", new OddEvenVersionPolicy());
-        Assert.assertEquals("1.0.0", info1.getReleaseVersionString());
-        Assert.assertEquals("1.0.1-SNAPSHOT", info1.nextSnapshotVersion());
+        Assertions.assertEquals("1.0.0", info1.getReleaseVersionString());
+        Assertions.assertEquals("1.0.1-SNAPSHOT", info1.nextSnapshotVersion());
 
 
         GitFlowVersionInfo info2 = new GitFlowVersionInfo("1.0.1-SNAPSHOT", new OddEvenVersionPolicy());
-        Assert.assertEquals("1.0.2", info2.getReleaseVersionString());
-        Assert.assertEquals("1.0.3-SNAPSHOT", info2.nextSnapshotVersion());
+        Assertions.assertEquals("1.0.2", info2.getReleaseVersionString());
+        Assertions.assertEquals("1.0.3-SNAPSHOT", info2.nextSnapshotVersion());
     }
 
 }

--- a/src/test/java/com/amashchenko/maven/plugin/gitflow/NextHotfixVersionTest.java
+++ b/src/test/java/com/amashchenko/maven/plugin/gitflow/NextHotfixVersionTest.java
@@ -18,25 +18,14 @@ package com.amashchenko.maven.plugin.gitflow;
 import java.util.Arrays;
 import java.util.Collection;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
 
-@RunWith(Parameterized.class)
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+
 public class NextHotfixVersionTest {
-    private final String version;
-    private final Integer index;
-    private final String expectedVersion;
 
-    public NextHotfixVersionTest(final String version, final Integer index, final String expectedVersion) {
-        this.version = version;
-        this.index = index;
-        this.expectedVersion = expectedVersion;
-    }
-
-    @Parameters(name = "{0}-({1})->{2}")
     public static Collection<Object[]> data() {
         return Arrays
                 .asList(new Object[][] {
@@ -61,8 +50,9 @@ public class NextHotfixVersionTest {
                                 { "2.3.4", 1, "2.4.0" } });
     }
 
-    @Test
-    public void testNextSnapshotVersion() throws Exception {
-        Assert.assertEquals(expectedVersion, new GitFlowVersionInfo(version, null).hotfixVersion(false, index));
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testNextSnapshotVersion(final String version, final Integer index, final String expectedVersion) throws Exception {
+        Assertions.assertEquals(expectedVersion, new GitFlowVersionInfo(version, null).hotfixVersion(false, index));
     }
 }

--- a/src/test/java/com/amashchenko/maven/plugin/gitflow/NextSnapshotVersionTest.java
+++ b/src/test/java/com/amashchenko/maven/plugin/gitflow/NextSnapshotVersionTest.java
@@ -15,29 +15,14 @@
  */
 package com.amashchenko.maven.plugin.gitflow;
 
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
 import java.util.Arrays;
 import java.util.Collection;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
-
-@RunWith(Parameterized.class)
 public class NextSnapshotVersionTest {
-    private final String version;
-    private final Integer index;
-    private final String expectedVersion;
-
-    public NextSnapshotVersionTest(final String version, final Integer index,
-            final String expectedVersion) {
-        this.version = version;
-        this.index = index;
-        this.expectedVersion = expectedVersion;
-    }
-
-    @Parameters
     public static Collection<Object[]> data() {
         return Arrays
                 .asList(new Object[][] {
@@ -64,9 +49,11 @@ public class NextSnapshotVersionTest {
                                 { "2.3.4", 1, "2.4.0-SNAPSHOT" } });
     }
 
-    @Test
-    public void testNextSnapshotVersion() throws Exception {
-        Assert.assertEquals(expectedVersion,
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testNextSnapshotVersion(final String version, final Integer index,
+                                        final String expectedVersion) throws Exception {
+        Assertions.assertEquals(expectedVersion,
                 new GitFlowVersionInfo(version, null).nextSnapshotVersion(index));
     }
 }

--- a/src/test/java/com/amashchenko/maven/plugin/gitflow/ValidateConfigurationTest.java
+++ b/src/test/java/com/amashchenko/maven/plugin/gitflow/ValidateConfigurationTest.java
@@ -15,27 +15,16 @@
  */
 package com.amashchenko.maven.plugin.gitflow;
 
+import org.apache.maven.plugin.MojoFailureException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
 import java.util.Arrays;
 import java.util.Collection;
 
-import org.apache.maven.plugin.MojoFailureException;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
-
-@RunWith(Parameterized.class)
 public class ValidateConfigurationTest {
-    private final String argLine;
-    private final boolean expected;
 
-    public ValidateConfigurationTest(String argLine, boolean expected) {
-        this.argLine = argLine;
-        this.expected = expected;
-    }
-
-    @Parameters(name = "{0}->{1}")
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][] { { "-X -e", true },
                         { "-DsomeArg1=true", true }, { null, true },
@@ -46,8 +35,9 @@ public class ValidateConfigurationTest {
                         { "-DsomeArg  ; clean", false } });
     }
 
-    @Test
-    public void testValidateConfiguration() throws Exception {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testValidateConfiguration(String argLine, boolean expected) throws Exception {
         GitFlowReleaseStartMojo mojo = new GitFlowReleaseStartMojo();
         mojo.setArgLine(argLine);
 
@@ -55,7 +45,7 @@ public class ValidateConfigurationTest {
             mojo.validateConfiguration();
         } catch (MojoFailureException e) {
             if (expected) {
-                Assert.fail();
+                Assertions.fail();
             }
         }
     }


### PR DESCRIPTION
implements #369

**57** builds in GitHub actions later, finally got this to run.

I reduced it to plexus-utils 1.X vs 3.X: it appears that there were major changes in encoding of parameters before&after.
Especially annoying, my private box is a windows machine & the issues occurred only on Linux/Ubuntu. For a while it seemed to be a CI vs. local issues (is the JDK not installed correctly? maven 3.9.X not installing as expected? Is there an issue with the actions/runners used?), until I reduced it to plexus-utils 1 vs 3.