### PR TITLE
Replace special characters with hyphen in featureName

### DIFF
--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowVersionInfo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowVersionInfo.java
@@ -28,10 +28,10 @@ import org.codehaus.plexus.util.StringUtils;
 /**
  * Git flow {@link org.apache.maven.shared.release.versions.VersionInfo}
  * implementation. Adds few convenient methods.
- * 
+ *
  */
 public class GitFlowVersionInfo extends DefaultVersionInfo {
-    
+
     private final VersionPolicy versionPolicy;
 
     public GitFlowVersionInfo(final String version, final VersionPolicy versionPolicy)
@@ -42,7 +42,7 @@ public class GitFlowVersionInfo extends DefaultVersionInfo {
 
     /**
      * Returns a new GitFlowVersionInfo that holds only digits in the version.
-     * 
+     *
      * @return Digits only GitFlowVersionInfo instance.
      * @throws VersionParseException
      *             If version parsing fails.
@@ -53,7 +53,7 @@ public class GitFlowVersionInfo extends DefaultVersionInfo {
 
     /**
      * Validates version.
-     * 
+     *
      * @param version
      *            Version to validate.
      * @return <code>true</code> when version is valid, <code>false</code>
@@ -80,7 +80,7 @@ public class GitFlowVersionInfo extends DefaultVersionInfo {
 
     /**
      * Gets next SNAPSHOT version.
-     * 
+     *
      * @return Next SNAPSHOT version.
      */
     public String nextSnapshotVersion() {
@@ -89,7 +89,7 @@ public class GitFlowVersionInfo extends DefaultVersionInfo {
 
     /**
      * Gets next SNAPSHOT version.
-     * 
+     *
      * @param index
      *            Which part of version to increment.
      * @return Next SNAPSHOT version.
@@ -101,7 +101,7 @@ public class GitFlowVersionInfo extends DefaultVersionInfo {
     /**
      * Gets next version. If index is <code>null</code> or not valid then it
      * delegates to {@link #getNextVersion()} method.
-     * 
+     *
      * @param index
      *            Which part of version to increment.
      * @param snapshot
@@ -147,7 +147,7 @@ public class GitFlowVersionInfo extends DefaultVersionInfo {
 
     /**
      * Gets version with appended feature name.
-     * 
+     *
      * @param featureName
      *            Feature name to append.
      * @return Version with appended feature name.
@@ -155,15 +155,20 @@ public class GitFlowVersionInfo extends DefaultVersionInfo {
     public String featureVersion(final String featureName) {
         String version = toString();
         if (featureName != null) {
-            version = getReleaseVersionString() + "-" + featureName
+            version = getReleaseVersionString() + "-" + getCleanedFeatureName(featureName)
                     + (isSnapshot() ? "-" + Artifact.SNAPSHOT_VERSION : "");
         }
         return version;
     }
 
+    public static String getCleanedFeatureName(String featureName) {
+        String cleanedFeatureName = featureName.replaceAll("[\\\\/:\"<>|?*]", "-");
+        return cleanedFeatureName.replaceAll("-+", "-");
+    }
+
     /**
      * Gets next hotfix version.
-     * 
+     *
      * @param preserveSnapshot
      *            Whether to preserve SNAPSHOT in the version.
      * @param index


### PR DESCRIPTION
In preparation for future Maven updates that may not support certain characters, this commit updates the featureVersion method to replace especial characters, including '/', ':', '"', '<', '>', '|', '?', '*', and '\', with a hyphen ('-') in the featureName parameter. Additionally, it ensures that multiple hyphens are not consecutively present in the result.

This allows branch names like "feature/2023-09-28/my-awesome-feature"