### PR TITLE
Added versionsProcessAllModules flag

### DIFF
--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
@@ -160,6 +160,14 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
     private boolean versionsForceUpdate = false;
 
     /**
+     * Whether to set -DprocessAllModules' when calling versions-maven-plugin.
+     * 
+     * @since 1.21.1
+     */
+    @Parameter(property = "versionsProcessAllModules", defaultValue = "false")
+    private Boolean versionsProcessAllModules;
+
+    /**
      * Property to set version to.
      *
      * @since 1.13.0
@@ -1173,6 +1181,9 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
                 if (versionsForceUpdate) {
                     args.add("-DgroupId=");
                     args.add("-DartifactId=");
+                }
+                if (versionsProcessAllModules) {
+                    args.add("-DprocessAllModules");
                 }
             }
 


### PR DESCRIPTION
Hi,

I am using a multi module project which does not have parent links in some modules (for valid reasons!).  When executing a `versions:set` command in this kind of project a flag is required to tell maven to update based upon the `modules` list not just the parent child links.

This flag is `-DprocessAllModules`.

My pull request adds a simple parameter to enable adding this flag during to the version set command, the default behaviour is exactly as before.