### PR TITLE
feat: @{version} replaced in gitPushOptions for (release|hotifx)-start

### DIFF
--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/AbstractGitFlowMojo.java
@@ -55,7 +55,7 @@ import com.amashchenko.maven.plugin.gitflow.prompter.GitFlowPrompter;
 
 /**
  * Abstract git flow mojo.
- * 
+ *
  */
 public abstract class AbstractGitFlowMojo extends AbstractMojo {
     /** Group and artifact id of the versions-maven-plugin. */
@@ -96,7 +96,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Git commit messages.
-     * 
+     *
      * @since 1.2.1
      */
     @Parameter(defaultValue = "${commitMessages}")
@@ -104,15 +104,15 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Whether this is Tycho build.
-     * 
+     *
      * @since 1.1.0
      */
     @Parameter(defaultValue = "false")
     protected boolean tychoBuild;
-    
+
     /**
      * Whether to call Maven install goal during the mojo execution.
-     * 
+     *
      * @since 1.0.5
      */
     @Parameter(property = "installProject", defaultValue = "false")
@@ -120,7 +120,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Whether to fetch remote branch and compare it with the local one.
-     * 
+     *
      * @since 1.3.0
      */
     @Parameter(property = "fetchRemote", defaultValue = "true")
@@ -128,7 +128,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Whether to print commands output into the console.
-     * 
+     *
      * @since 1.0.7
      */
     @Parameter(property = "verbose", defaultValue = "false")
@@ -136,7 +136,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Command line arguments to pass to the underlying Maven commands.
-     * 
+     *
      * @since 1.8.0
      */
     @Parameter(property = "argLine")
@@ -144,7 +144,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Whether to make a GPG-signed commit.
-     * 
+     *
      * @since 1.9.0
      */
     @Parameter(property = "gpgSignCommit", defaultValue = "false")
@@ -153,7 +153,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
     /**
      * Whether to set -DgroupId='*' -DartifactId='*' when calling
      * versions-maven-plugin.
-     * 
+     *
      * @since 1.10.0
      */
     @Parameter(property = "versionsForceUpdate", defaultValue = "false")
@@ -170,7 +170,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
     /**
      * Whether to skip updating version. Useful with {@link #versionProperty} to be
      * able to update <code>revision</code> property without modifying version tag.
-     * 
+     *
      * @since 1.13.0
      */
     @Parameter(property = "skipUpdateVersion")
@@ -178,7 +178,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Prefix that is applied to commit messages.
-     * 
+     *
      * @since 1.14.0
      */
     @Parameter(property = "commitMessagePrefix")
@@ -207,7 +207,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Version of versions-maven-plugin to use.
-     * 
+     *
      * @since 1.18.0
      */
     @Parameter(property = "versionsMavenPluginVersion", defaultValue = "2.16.0")
@@ -215,7 +215,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Version of tycho-versions-plugin to use.
-     * 
+     *
      * @since 1.18.0
      */
     @Parameter(property = "tychoVersionsPluginVersion", defaultValue = "1.7.0")
@@ -226,7 +226,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
      * Multiple options can be added separated with a space e.g.
      * <code>-DgitPushOptions="merge_request.create merge_request.target=develop
      * merge_request.label='Super feature'"</code>
-     * 
+     *
      * @since 1.18.0
      */
     @Parameter(property = "gitPushOptions")
@@ -236,7 +236,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
      * Explicitly enable or disable executing Git submodule update before commit. By
      * default plugin tries to automatically determine if update of the Git
      * submodules is needed.
-     * 
+     *
      * @since 1.19.0
      */
     @Parameter(property = "updateGitSubmodules")
@@ -259,7 +259,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     @Component
     protected ProjectBuilder projectBuilder;
-    
+
     /** Default prompter. */
     @Component
     protected GitFlowPrompter prompter;
@@ -276,7 +276,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Initializes command line executables.
-     * 
+     *
      */
     private void initExecutables() {
         if (StringUtils.isBlank(cmdMvn.getExecutable())) {
@@ -303,7 +303,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
     /**
      * Validates plugin configuration. Throws exception if configuration is not
      * valid.
-     * 
+     *
      * @param params
      *            Configuration parameters to validate.
      * @throws MojoFailureException
@@ -324,7 +324,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Gets current project version from pom.xml file.
-     * 
+     *
      * @return Current project version.
      * @throws MojoFailureException
      *          If current project version cannot be obtained.
@@ -341,7 +341,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
     /**
      * Gets current project {@link #REPRODUCIBLE_BUILDS_PROPERTY} property value
      * from pom.xml file.
-     * 
+     *
      * @return Value of {@link #REPRODUCIBLE_BUILDS_PROPERTY} property.
      * @throws MojoFailureException
      *             If project loading fails.
@@ -353,7 +353,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Reloads projects info from file.
-     * 
+     *
      * @param project
      * @return Reloaded Maven projects.
      * @throws MojoFailureException
@@ -378,7 +378,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Reloads project info from file.
-     * 
+     *
      * @param project
      * @return Maven project which is the execution root.
      * @throws MojoFailureException
@@ -397,7 +397,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Compares the production branch name with the development branch name.
-     * 
+     *
      * @return <code>true</code> if the production branch name is different from
      *         the development branch name, <code>false</code> otherwise.
      */
@@ -407,7 +407,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Checks uncommitted changes.
-     * 
+     *
      * @throws MojoFailureException
      *             If there is some uncommitted files.
      * @throws CommandLineException
@@ -460,7 +460,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Checks if branch name is acceptable.
-     * 
+     *
      * @param branchName
      *            Branch name to check.
      * @return <code>true</code> when name is valid, <code>false</code> otherwise.
@@ -476,7 +476,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Checks if version is valid.
-     * 
+     *
      * @param version
      *            Version to validate.
      * @return <code>true</code> when version is valid, <code>false</code>
@@ -496,7 +496,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git commands to check for uncommitted changes.
-     * 
+     *
      * @return <code>true</code> when there are uncommitted changes,
      *         <code>false</code> otherwise.
      * @throws CommandLineException
@@ -537,7 +537,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git config commands to set Git Flow configuration.
-     * 
+     *
      * @throws MojoFailureException
      *             Shouldn't happen, actually.
      * @throws CommandLineException
@@ -558,7 +558,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git config command.
-     * 
+     *
      * @param name
      *            Option name.
      * @param value
@@ -584,7 +584,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git for-each-ref with <code>refname:short</code> format.
-     * 
+     *
      * @param branchName
      *            Branch name to find.
      * @param firstMatch
@@ -601,7 +601,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git for-each-ref with <code>refname:short</code> format.
-     * 
+     *
      * @param refs
      *            Refs to search.
      * @param branchName
@@ -675,7 +675,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Removes double quotes from the string.
-     * 
+     *
      * @param str
      *            String to remove quotes from.
      * @return String without quotes.
@@ -686,7 +686,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Gets the current branch name.
-     * 
+     *
      * @return Current branch name.
      * @throws MojoFailureException
      *             If command line execution returns false code.
@@ -788,25 +788,26 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Replaces properties in message.
-     * 
+     *
      * @param message
      * @param map
      *            Key is a string to replace wrapped in <code>@{...}</code>. Value
      *            is a string to replace with.
      * @return Message with replaced properties.
      */
-    private String replaceProperties(String message, Map<String, String> map) {
+    private String replaceProperties(final String message, final Map<String, String> map) {
+    	String messageModified = message;
         if (map != null) {
             for (Entry<String, String> entr : map.entrySet()) {
-                message = StringUtils.replace(message, "@{" + entr.getKey() + "}", entr.getValue());
+            	messageModified = StringUtils.replace(message, "@{" + entr.getKey() + "}", entr.getValue());
             }
         }
-        return message;
+        return messageModified;
     }
 
     /**
      * Executes git commit -a -m.
-     * 
+     *
      * @param message
      *            Commit message.
      * @throws MojoFailureException
@@ -821,7 +822,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
     /**
      * Executes git commit -a -m, replacing <code>@{map.key}</code> with
      * <code>map.value</code>.
-     * 
+     *
      * @param message
      *            Commit message.
      * @param messageProperties
@@ -856,7 +857,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git rebase or git merge --ff-only or git merge --no-ff or git merge.
-     * 
+     *
      * @param branchName
      *            Branch name to merge.
      * @param rebase
@@ -908,7 +909,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git merge --no-ff.
-     * 
+     *
      * @param branchName
      *            Branch name to merge.
      * @param message
@@ -927,7 +928,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git merge --squash.
-     * 
+     *
      * @param branchName
      *            Branch name to merge.
      * @throws MojoFailureException
@@ -942,7 +943,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git tag -a [-s] -m.
-     * 
+     *
      * @param tagName
      *            Name of the tag.
      * @param message
@@ -973,7 +974,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git branch -d.
-     * 
+     *
      * @param branchName
      *            Branch name to delete.
      * @throws MojoFailureException
@@ -989,7 +990,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git branch -D.
-     * 
+     *
      * @param branchName
      *            Branch name to delete.
      * @throws MojoFailureException
@@ -1006,7 +1007,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
     /**
      * Executes git fetch and checks if local branch exists. If local branch is
      * present then compares it with the remote, if not then branch is checked out.
-     * 
+     *
      * @param branchName
      *            Branch name to check.
      * @throws MojoFailureException
@@ -1039,7 +1040,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
     /**
      * Executes git fetch and git for-each-ref with <code>refname:short</code>
      * format. Searches <code>refs/remotes/{gitFlowConfig#origin}/</code>.
-     * 
+     *
      * @param branchName
      *            Branch name to find.
      * @param firstMatch
@@ -1059,7 +1060,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git fetch.
-     * 
+     *
      * @return <code>true</code> if git fetch returned success exit code,
      *         <code>false</code> otherwise.
      * @throws MojoFailureException
@@ -1085,7 +1086,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes git push, optionally with the <code>--follow-tags</code> argument.
-     * 
+     *
      * @param branchName
      *            Branch name to push.
      * @param pushTags
@@ -1096,7 +1097,26 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
      * @throws CommandLineException
      *             If command line execution fails.
      */
-    protected void gitPush(final String branchName, boolean pushTags) throws MojoFailureException, CommandLineException {
+    protected void gitPush(final String branchName, final boolean pushTags) throws MojoFailureException, CommandLineException {
+    	gitPush(branchName, pushTags, null);
+    }
+
+    /**
+     * Executes git push, optionally with the <code>--follow-tags</code> argument.
+     *
+     * @param branchName
+     *            Branch name to push.
+     * @param pushTags
+     *            If <code>true</code> adds <code>--follow-tags</code> argument to
+     *            the git <code>push</code> command.
+     * @param messageProperties
+     *            Properties to replace in message.
+     * @throws MojoFailureException
+     *             If command line execution returns false code.
+     * @throws CommandLineException
+     *             If command line execution fails.
+     */
+    protected void gitPush(final String branchName, final boolean pushTags, final Map<String, String> messageProperties) throws MojoFailureException, CommandLineException {
         getLog().info("Pushing '" + branchName + "' branch to '" + gitFlowConfig.getOrigin() + "'.");
 
         List<String> args = new ArrayList<>();
@@ -1110,7 +1130,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
         if (StringUtils.isNotBlank(gitPushOptions)) {
             try {
-                String[] opts = CommandLineUtils.translateCommandline(gitPushOptions);
+                String[] opts = CommandLineUtils.translateCommandline(replaceProperties(gitPushOptions, messageProperties));
                 for (String opt : opts) {
                     args.add("--push-option=" + opt);
                 }
@@ -1140,7 +1160,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
     /**
      * Executes 'set' goal of versions-maven-plugin or 'set-version' of
      * tycho-versions-plugin in case it is tycho build.
-     * 
+     *
      * @param version
      *            New version to set.
      * @throws MojoFailureException
@@ -1213,7 +1233,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes mvn clean test.
-     * 
+     *
      * @throws MojoFailureException
      *             If command line execution returns false code.
      * @throws CommandLineException
@@ -1230,7 +1250,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes mvn clean install.
-     * 
+     *
      * @throws MojoFailureException
      *             If command line execution returns false code.
      * @throws CommandLineException
@@ -1244,7 +1264,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes Maven goals.
-     * 
+     *
      * @param goals
      *            The goals to execute.
      * @throws Exception
@@ -1258,7 +1278,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes Git command and returns output.
-     * 
+     *
      * @param args
      *            Git command line arguments.
      * @return Command output.
@@ -1274,7 +1294,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes Git command without failing on non successful exit code.
-     * 
+     *
      * @param args
      *            Git command line arguments.
      * @return Command result.
@@ -1290,7 +1310,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes Git command.
-     * 
+     *
      * @param args
      *            Git command line arguments.
      * @throws CommandLineException
@@ -1305,7 +1325,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes Maven command.
-     * 
+     *
      * @param args
      *            Maven command line arguments.
      * @throws CommandLineException
@@ -1320,7 +1340,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
 
     /**
      * Executes command line.
-     * 
+     *
      * @param cmd
      *            Command line.
      * @param failOnError
@@ -1413,7 +1433,7 @@ public abstract class AbstractGitFlowMojo extends AbstractMojo {
         }
     }
 
-    public void setArgLine(String argLine) {
+    public void setArgLine(final String argLine) {
         this.argLine = argLine;
     }
 

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowHotfixStartMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowHotfixStartMojo.java
@@ -30,14 +30,14 @@ import org.codehaus.plexus.util.cli.CommandLineException;
 
 /**
  * The git flow hotfix start mojo.
- * 
+ *
  */
 @Mojo(name = "hotfix-start", aggregator = true)
 public class GitFlowHotfixStartMojo extends AbstractGitFlowMojo {
 
     /**
      * Whether to push to the remote.
-     * 
+     *
      * @since 1.6.0
      */
     @Parameter(property = "pushRemote", defaultValue = "false")
@@ -46,7 +46,7 @@ public class GitFlowHotfixStartMojo extends AbstractGitFlowMojo {
     /**
      * Branch to start hotfix in non-interactive mode. Production branch or one of
      * the support branches.
-     * 
+     *
      * @since 1.9.0
      */
     @Parameter(property = "fromBranch")
@@ -54,7 +54,7 @@ public class GitFlowHotfixStartMojo extends AbstractGitFlowMojo {
 
     /**
      * Hotfix version to use in non-interactive mode.
-     * 
+     *
      * @since 1.9.0
      */
     @Parameter(property = "hotfixVersion")
@@ -62,7 +62,7 @@ public class GitFlowHotfixStartMojo extends AbstractGitFlowMojo {
 
     /**
      * Whether to use snapshot in hotfix.
-     * 
+     *
      * @since 1.10.0
      */
     @Parameter(property = "useSnapshotInHotfix", defaultValue = "false")
@@ -177,6 +177,8 @@ public class GitFlowHotfixStartMojo extends AbstractGitFlowMojo {
             // git checkout -b hotfix/... ...
             gitCreateAndCheckout(hotfixBranchName, branchName);
 
+            Map<String, String> properties = new HashMap<>();
+            properties.put("version", version);
             // execute if version changed
             if (!version.equals(currentVersion)) {
                 String projectVersion = version;
@@ -193,7 +195,6 @@ public class GitFlowHotfixStartMojo extends AbstractGitFlowMojo {
 
                 mvnSetVersions(projectVersion);
 
-                Map<String, String> properties = new HashMap<>();
                 properties.put("version", projectVersion);
 
                 gitCommit(commitMessages.getHotfixStartMessage(), properties);
@@ -204,7 +205,7 @@ public class GitFlowHotfixStartMojo extends AbstractGitFlowMojo {
             }
 
             if (pushRemote) {
-                gitPush(hotfixBranchName, false);
+                gitPush(hotfixBranchName, false, properties);
             }
         } catch (CommandLineException | VersionParseException e) {
             throw new MojoFailureException("hotfix-start", e);

--- a/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowReleaseStartMojo.java
+++ b/src/main/java/com/amashchenko/maven/plugin/gitflow/GitFlowReleaseStartMojo.java
@@ -30,7 +30,7 @@ import org.codehaus.plexus.util.cli.CommandLineException;
 
 /**
  * The git flow release start mojo.
- * 
+ *
  */
 @Mojo(name = "release-start", aggregator = true)
 public class GitFlowReleaseStartMojo extends AbstractGitFlowMojo {
@@ -45,7 +45,7 @@ public class GitFlowReleaseStartMojo extends AbstractGitFlowMojo {
      * Note: By itself the default releaseBranchPrefix is not a valid branch
      * name. You must change it when setting sameBranchName to <code>true</code>
      * .
-     * 
+     *
      * @since 1.2.0
      */
     @Parameter(property = "sameBranchName", defaultValue = "false")
@@ -53,7 +53,7 @@ public class GitFlowReleaseStartMojo extends AbstractGitFlowMojo {
 
     /**
      * Whether to allow SNAPSHOT versions in dependencies.
-     * 
+     *
      * @since 1.2.2
      */
     @Parameter(property = "allowSnapshots", defaultValue = "false")
@@ -62,7 +62,7 @@ public class GitFlowReleaseStartMojo extends AbstractGitFlowMojo {
     /**
      * Release version to use instead of the default next release version in non
      * interactive mode.
-     * 
+     *
      * @since 1.3.1
      */
     @Parameter(property = "releaseVersion", defaultValue = "")
@@ -80,7 +80,7 @@ public class GitFlowReleaseStartMojo extends AbstractGitFlowMojo {
      * Whether to commit development version when starting the release (vs when
      * finishing the release which is the default). Has effect only when there
      * are separate development and production branches.
-     * 
+     *
      * @since 1.7.0
      */
     @Parameter(property = "commitDevelopmentVersionAtStart", defaultValue = "false")
@@ -113,7 +113,7 @@ public class GitFlowReleaseStartMojo extends AbstractGitFlowMojo {
 
     /**
      * Start a release branch from this commit (SHA).
-     * 
+     *
      * @since 1.7.0
      */
     @Parameter(property = "fromCommit")
@@ -121,7 +121,7 @@ public class GitFlowReleaseStartMojo extends AbstractGitFlowMojo {
 
     /**
      * Whether to use snapshot in release.
-     * 
+     *
      * @since 1.10.0
      */
     @Parameter(property = "useSnapshotInRelease", defaultValue = "false")
@@ -131,7 +131,7 @@ public class GitFlowReleaseStartMojo extends AbstractGitFlowMojo {
      * Name of the created release branch.<br>
      * The effective branch name will be a composite of this branch name and the
      * <code>releaseBranchPrefix</code>.
-     * 
+     *
      * @since 1.14.0
      */
     @Parameter(property = "branchName")
@@ -228,11 +228,14 @@ public class GitFlowReleaseStartMojo extends AbstractGitFlowMojo {
             }
 
             if (pushRemote) {
+            	Map<String, String> properties = new HashMap<>();
+                properties.put("version", projectVersion);
+
                 if (commitDevelopmentVersionAtStart) {
-                    gitPush(gitFlowConfig.getDevelopmentBranch(), false);
+                    gitPush(gitFlowConfig.getDevelopmentBranch(), false, properties);
                 }
 
-                gitPush(fullBranchName, false);
+                gitPush(fullBranchName, false, properties);
             }
         } catch (CommandLineException | VersionParseException e) {
             throw new MojoFailureException("release-start", e);


### PR DESCRIPTION
Hi I'm using MR to push changes to the production branch and I want to use @{version} within gitPushOptions to set the correct message like this

<gitPushOptions>merge_request.create merge_request.target=main merge_request.title="Release @{version} to main"</gitPushOptions>